### PR TITLE
fix metadata for IBC denoms

### DIFF
--- a/pyinjective/denoms_devnet.ini
+++ b/pyinjective/denoms_devnet.ini
@@ -81,7 +81,7 @@ min_display_quantity_tick_size = 0.001
 
 [0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa]
 description = 'Devnet Spot ATOM/USDT'
-base = 0
+base = 6
 quote = 6
 min_price_tick_size = 1000000000
 min_display_price_tick_size = 1000.0
@@ -160,21 +160,30 @@ min_display_price_tick_size = 0.001
 min_quantity_tick_size = 0.001
 min_display_quantity_tick_size = 0.001
 
+[0xa20fad9a8f55c924f6b3b3d2db8e90716ce19f081b67c0790285eb499deb1c0d]
+description = 'Devnet Derivative BTC/USDC PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.01
+min_display_quantity_tick_size = 0.01
+
 [0x3400e8d1c785b00edc28c08e9671135830f9a52198944d27850c7818c46c3a3a]
 description = 'Devnet Derivative ETH/USDT PERP BAND'
 base = 0
 quote = 6
-min_price_tick_size = 10000
-min_display_price_tick_size = 0.01
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
 min_quantity_tick_size = 0.01
 min_display_quantity_tick_size = 0.01
 
-[0x56744ee6b652c15fc93c44263e2b274944bad87ef7aaa3c29ee6c7f8a5762c58]
-description = 'Devnet Derivative BNB/USDT PERP BAND'
+[0x1c79dac019f73e4060494ab1b4fcba734350656d6fc4d474f6a238c13c6f9ced]
+description = 'Devnet Derivative BNB/USDT PERP'
 base = 0
 quote = 6
-min_price_tick_size = 10000
-min_display_price_tick_size = 0.01
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
 min_quantity_tick_size = 0.01
 min_display_quantity_tick_size = 0.01
 
@@ -215,6 +224,10 @@ peggy_denom = peggy0xE41d2489571d322189246DaFA5ebDe1F4699F498
 decimals = 18
 
 [USDC]
-peggy_denom = peggy0xdAC17F958D2ee523a2206206994597C13D831ec7
+peggy_denom = peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+decimals = 6
+
+[ATOM]
+peggy_denom = ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
 decimals = 6
 

--- a/pyinjective/denoms_mainnet.ini
+++ b/pyinjective/denoms_mainnet.ini
@@ -180,16 +180,16 @@ min_display_quantity_tick_size = 0.0001
 
 [0x7471d361b90fc8541267bd088f498c2a461a2c0c57ff2b9a08279480e803b470]
 description = 'Mainnet Spot AXS/USDT'
-base = 0
-quote = 0
+base = 18
+quote = 6
 min_price_tick_size = 0.00000000000001
-min_display_price_tick_size = 1e-14
+min_display_price_tick_size = 0.01
 min_quantity_tick_size = 10000000000000000
-min_display_quantity_tick_size = 1e+16
+min_display_quantity_tick_size = 0.01
 
 [0x0511ddc4e6586f3bfe1acb2dd905f8b8a82c97e1edaef654b12ca7e6031ca0fa]
 description = 'Mainnet Spot ATOM/USDT'
-base = 0
+base = 6
 quote = 6
 min_price_tick_size = 0.01
 min_display_price_tick_size = 1e-08
@@ -222,6 +222,15 @@ min_price_tick_size = 10000
 min_display_price_tick_size = 0.01
 min_quantity_tick_size = 0.01
 min_display_quantity_tick_size = 0.01
+
+[0x9b9980167ecc3645ff1a5517886652d94a0825e54a77d2057cbbe3ebee015963]
+description = 'Mainnet Derivative INJ/USDT PERP'
+base = 0
+quote = 6
+min_price_tick_size = 1000
+min_display_price_tick_size = 0.001
+min_quantity_tick_size = 0.001
+min_display_quantity_tick_size = 0.001
 
 [WETH]
 peggy_denom = peggy0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
@@ -274,4 +283,12 @@ decimals = 18
 [WBTC]
 peggy_denom = peggy0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599
 decimals = 8
+
+[AXS]
+peggy_denom = peggy0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b
+decimals = 18
+
+[ATOM]
+peggy_denom = ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9
+decimals = 6
 

--- a/pyinjective/fetch_metadata.py
+++ b/pyinjective/fetch_metadata.py
@@ -41,10 +41,10 @@ async def fetch_denom(network) -> str:
         mresp = await spot_exchange_rpc.Markets(spot_exchange_rpc_pb.MarketsRequest(market_status=status))
         for market in mresp.markets:
             # append symbols to dict
-            if market.base_token_meta.SerializeToString() != b'':
+            if market.base_token_meta.SerializeToString() != '':
                 symbols[market.base_token_meta.symbol] = (market.base_denom, market.base_token_meta.decimals)
 
-            if market.quote_token_meta.SerializeToString() != b'':
+            if market.quote_token_meta.SerializeToString() != '':
                 symbols[market.quote_token_meta.symbol] = (market.base_denom, market.quote_token_meta.decimals)
 
             # format into ini entry
@@ -69,7 +69,7 @@ async def fetch_denom(network) -> str:
         mresp = await derivative_exchange_rpc.Markets(derivative_exchange_rpc_pb.MarketsRequest(market_status=status))
         for market in mresp.markets:
             # append symbols to dict
-            if market.quote_token_meta.SerializeToString() != b'':
+            if market.quote_token_meta.SerializeToString() != '':
                 symbols[market.quote_token_meta.symbol] = (market.quote_denom, market.quote_token_meta.decimals)
 
             # format into ini entry
@@ -97,17 +97,17 @@ async def fetch_denom(network) -> str:
 async def main() -> None:
     devnet = Network.devnet()
     data = await fetch_denom(devnet)
-    with open("./pyinjective/denoms_devnet.ini", "w") as text_file:
+    with open("denoms_devnet.ini", "w") as text_file:
         text_file.write(data)
 
     testnet = Network.testnet()
     data = await fetch_denom(testnet)
-    with open("./pyinjective/denoms_testnet.ini", "w") as text_file:
+    with open("denoms_testnet.ini", "w") as text_file:
         text_file.write(data)
 
     mainnet = Network.mainnet()
     data = await fetch_denom(mainnet)
-    with open("./pyinjective/denoms_mainnet.ini", "w") as text_file:
+    with open("denoms_mainnet.ini", "w") as text_file:
         text_file.write(data)
 
 if __name__ == '__main__':


### PR DESCRIPTION
With this minor change: https://github.com/InjectiveLabs/sdk-python/compare/fix_ibc?expand=1#diff-b7d4bf70321d26e4e95834c64a19fb44d865a766578eb984c2fda18f0e464b5eR72 we can also fetch IBC denoms. I went ahead and hardcoded the decimals for ATOM since we haven't deployed the fix to fetch IBC token metadata on mainnet yet but this should be resolved when we do.