### PR TITLE
chore: fix timeout_height func

### DIFF
--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -173,8 +173,11 @@ class AsyncClient:
         self.cron.stop()
 
     async def sync_timeout_height(self):
-        block = await self.get_latest_block()
-        self.timeout_height = block.block.header.height + DEFAULT_TIMEOUTHEIGHT
+        try:
+            block = await self.get_latest_block()
+            self.timeout_height = block.block.header.height + DEFAULT_TIMEOUTHEIGHT
+        except Exception as e:
+            self.timeout_height = 0
 
     # cookie helper methods
     async def fetch_cookie(self, type):

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -176,7 +176,8 @@ class AsyncClient:
         try:
             block = await self.get_latest_block()
             self.timeout_height = block.block.header.height + DEFAULT_TIMEOUTHEIGHT
-        except Exception:
+        except Exception as e:
+            logging.debug("error while fetching latest block, setting timeout height to 0:{}".format(e))
             self.timeout_height = 0
 
     # cookie helper methods

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -176,7 +176,7 @@ class AsyncClient:
         try:
             block = await self.get_latest_block()
             self.timeout_height = block.block.header.height + DEFAULT_TIMEOUTHEIGHT
-        except Exception as e:
+        except Exception:
             self.timeout_height = 0
 
     # cookie helper methods


### PR DESCRIPTION
@vinhphuctadang should fix the occasional errors on the client we saw while trying to fetch the block.

Setting timeout_height as 0 is fine in most cases, we can default to 0 if LCD is not reachable. Clients should not be reliable to LCD since we handle sequence locally.