### PR TITLE
fix(exchange-examples): fix invalid parameters in orderbook snapshot examples

### DIFF
--- a/examples/exchange_client/derivative_exchange_rpc/5_StreamOrderbookSnapshot.py
+++ b/examples/exchange_client/derivative_exchange_rpc/5_StreamOrderbookSnapshot.py
@@ -4,11 +4,12 @@ import logging
 from pyinjective.async_client import AsyncClient
 from pyinjective.constant import Network
 
+
 async def main() -> None:
     network = Network.testnet()
     client = AsyncClient(network, insecure=False)
     market_id = "0x4ca0f92fc28be0c9761326016b5a1a2177dd6375558365116b5bdda9abc229ce"
-    markets = await client.stream_derivative_orderbook_snapshot(market_id=market_id)
+    markets = await client.stream_derivative_orderbook_snapshot(market_ids=[market_id])
     async for market in markets:
         print(market)
 

--- a/examples/exchange_client/spot_exchange_rpc/7_StreamOrderbookSnapshot.py
+++ b/examples/exchange_client/spot_exchange_rpc/7_StreamOrderbookSnapshot.py
@@ -4,11 +4,12 @@ import logging
 from pyinjective.async_client import AsyncClient
 from pyinjective.constant import Network
 
+
 async def main() -> None:
     network = Network.testnet()
     client = AsyncClient(network, insecure=False)
     market_id = "0xa508cb32923323679f29a032c70342c147c17d0145625922b0ef22e955c844c0"
-    orderbook = await client.stream_spot_orderbook_snapshot(market_id=market_id)
+    orderbook = await client.stream_spot_orderbook_snapshot(market_ids=[market_id])
     async for orders in orderbook:
         print(orders)
 


### PR DESCRIPTION
Fixes wrong parameter type, as the new APIs expect a list of market IDs