### PR TITLE
chore: set LB as default and deprecate K8S

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Note that the [sync client](https://github.com/InjectiveLabs/sdk-python/blob/mas
 
 ### Changelogs
 **0.6.0.9**
+* Deprecate K8S and set LB as default
 * Proto re-gen
 
 **0.6.0.8**

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -97,17 +97,11 @@ class AsyncClient:
         self.expiration_format = None
         self.load_balancer = load_balancer
         self.network = network
+        self.cookie_type = "GCLB"
+        self.expiration_format = "{}"
 
         if self.network.string() == "testnet":
             self.load_balancer = False
-
-        if self.load_balancer is False:
-            self.cookie_type = "grpc-cookie"
-            self.expiration_format = "20{}"
-
-        else:
-            self.cookie_type = "GCLB"
-            self.expiration_format = "{}"
 
         # chain stubs
         self.chain_channel = (

--- a/pyinjective/constant.py
+++ b/pyinjective/constant.py
@@ -118,13 +118,7 @@ class Network:
         if node not in nodes:
             raise ValueError('Must be one of {}'.format(nodes))
 
-        if node == 'k8s':
-            lcd_endpoint='https://k8s.mainnet.lcd.injective.network:443'
-            tm_websocket_endpoint='wss://k8s.mainnet.tm.injective.network:443/websocket'
-            grpc_endpoint='k8s.mainnet.chain.grpc.injective.network:443'
-            grpc_exchange_endpoint='k8s.mainnet.exchange.grpc.injective.network:443'
-            grpc_explorer_endpoint='k8s.mainnet.explorer.grpc.injective.network:443'
-        elif node == 'lb':
+        if node == 'lb':
             lcd_endpoint = 'https://k8s.global.mainnet.lcd.injective.network:443'
             tm_websocket_endpoint = 'wss://k8s.global.mainnet.tm.injective.network:443/websocket'
             grpc_endpoint = 'k8s.global.mainnet.chain.grpc.injective.network:443'


### PR DESCRIPTION
This PR removes K8S support from endpoints and cookie and sets LB as the default