### PR TITLE
Fix/configure lcd urls for each server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ make tests
 ### Changelogs
 **0.7**
 * Removed references to pysha3 library (and also eip712-struct that required it) and replaced it with other implementation to allow the project to work with Python 3.11
+* Updated sentry nodes LCD URL, for each sentry node to use its own service
 
 **0.6.5**
 * Removed `k8s` from the list of supported mainnet nodes (`lb` should be used instead)

--- a/pyinjective/constant.py
+++ b/pyinjective/constant.py
@@ -124,7 +124,7 @@ class Network:
             grpc_exchange_endpoint = 'k8s.global.mainnet.exchange.grpc.injective.network:443'
             grpc_explorer_endpoint = 'k8s.global.mainnet.explorer.grpc.injective.network:443'
         else:
-            lcd_endpoint='https://lcd.injective.network'
+            lcd_endpoint=f'http://{node}.injective.network:10337'
             tm_websocket_endpoint=f'ws://{node}.injective.network:26657/websocket'
             grpc_endpoint=f'{node}.injective.network:9900'
             grpc_exchange_endpoint=f'{node}.injective.network:9910'


### PR DESCRIPTION
- Changed the sentry nodes LCD URL configuration for each sentry node to use its local service instead of the global service