### PR TITLE
Fix/msg subaccount transfer amount translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ make tests
 ```
 
 ### Changelogs
+** 0.7.0.5 **
+* Added the required logic in the MsgSubaccountTransfer message to translate amounts and token into the correct amount and token name representation for the chain
+
 ** 0.7.0.4**
 * Synchronized decimals for ATOM and WETH in Testnet with the configuration provided by the indexer
 

--- a/examples/chain_client/16_MsgSubaccountTransfer.py
+++ b/examples/chain_client/16_MsgSubaccountTransfer.py
@@ -31,7 +31,7 @@ async def main() -> None:
         source_subaccount_id=subaccount_id,
         destination_subaccount_id=dest_subaccount_id,
         amount=100,
-        denom="inj"
+        denom="INJ"
     )
 
     # build sim tx

--- a/pyinjective/composer.py
+++ b/pyinjective/composer.py
@@ -625,12 +625,13 @@ class Composer:
         amount: int,
         denom: str,
     ):
-
+        peggy_denom, decimals = Denom.load_peggy_denom(self.network, denom)
+        be_amount = amount_to_backend(amount, decimals)
         return injective_exchange_tx_pb.MsgSubaccountTransfer(
             sender=sender,
             source_subaccount_id=source_subaccount_id,
             destination_subaccount_id=destination_subaccount_id,
-            amount=self.Coin(amount=amount, denom=denom),
+            amount=self.Coin(amount=be_amount, denom=peggy_denom),
         )
 
     def MsgWithdraw(self, sender: str, subaccount_id: str, amount: float, denom: str):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ URL = "https://github.com/InjectiveLabs/sdk-python"
 EMAIL = "achilleas@injectivelabs.com"
 AUTHOR = "Injective Labs"
 REQUIRES_PYTHON = ">=3.9"
-VERSION = "0.7.0.4"
+VERSION = "0.7.0.5"
 
 REQUIRED = [
     "aiohttp",


### PR DESCRIPTION
- Added the required logic in the MsgSubaccountTransfer message to translate amounts and token into the correct amount and token name representation for the chain