### PR TITLE
add MsgWithdrawValidatorCommission

### DIFF
--- a/examples/chain_client/48_WithdrawValidatorCommission_Rewards
+++ b/examples/chain_client/48_WithdrawValidatorCommission_Rewards
@@ -1,0 +1,79 @@
+
+import asyncio
+import logging
+
+from pyinjective.composer import Composer as ProtoMsgComposer
+from pyinjective.async_client import AsyncClient
+from pyinjective.transaction import Transaction
+from pyinjective.constant import Network
+from pyinjective.wallet import PrivateKey
+
+
+async def main() -> None:
+    """For a validator to withdraw his rewards & commissions simultaneously"""
+    # select network: local, testnet, mainnet
+    network = Network.testnet()
+    composer = ProtoMsgComposer(network=network.string())
+
+    # initialize grpc client
+    client = AsyncClient(network, insecure=False)
+    await client.sync_timeout_height()
+
+    # load account
+    # private key is that from the validator's wallet
+    priv_key = PrivateKey.from_hex("f9db9bf330e23cb7839039e944adef6e9df447b90b503d5b4464c90bea9022f3")
+    pub_key = priv_key.to_public_key()
+    address = pub_key.to_address()
+    account = await client.get_account(address.to_acc_bech32())
+
+    # prepare tx msg
+    validator_address = "injvaloper1ultw9r29l8nxy5u6thcgusjn95vsy2caw722q5"
+
+    msg0 = composer.MsgWithdrawDelegatorReward(
+        delegator_address=address.to_acc_bech32(),
+        validator_address=validator_address
+    )
+
+    msg1 = composer.MsgWithdrawValidatorCommission(
+        validator_address=validator_address
+    )
+
+    # build sim tx
+    tx = (
+        Transaction()
+        .with_messages(msg0, msg1)
+        .with_sequence(client.get_sequence())
+        .with_account_num(client.get_number())
+        .with_chain_id(network.chain_id)
+    )
+    sim_sign_doc = tx.get_sign_doc(pub_key)
+    sim_sig = priv_key.sign(sim_sign_doc.SerializeToString())
+    sim_tx_raw_bytes = tx.get_tx_data(sim_sig, pub_key)
+
+    # simulate tx
+    (sim_res, success) = await client.simulate_tx(sim_tx_raw_bytes)
+    if not success:
+        print(sim_res)
+        return
+
+    # build tx
+    gas_price = 500000000
+    gas_limit = sim_res.gas_info.gas_used + 20000 # add 20k for gas, fee computation
+    gas_fee = '{:.18f}'.format((gas_price * gas_limit) / pow(10, 18)).rstrip('0')
+    fee = [composer.Coin(
+        amount=gas_price * gas_limit,
+        denom=network.fee_denom,
+    )]
+    tx = tx.with_gas(gas_limit).with_fee(fee).with_memo('').with_timeout_height(client.timeout_height)
+    sign_doc = tx.get_sign_doc(pub_key)
+    sig = priv_key.sign(sign_doc.SerializeToString())
+    tx_raw_bytes = tx.get_tx_data(sig, pub_key)
+
+    # broadcast tx: send_tx_async_mode, send_tx_sync_mode, send_tx_block_mode
+    res = await client.send_tx_sync_mode(tx_raw_bytes)
+    print(res)
+    print("gas wanted: {}".format(gas_limit))
+    print("gas fee: {} INJ".format(gas_fee))
+
+if __name__ == "__main__":
+    asyncio.get_event_loop().run_until_complete(main())

--- a/pyinjective/composer.py
+++ b/pyinjective/composer.py
@@ -881,6 +881,14 @@ class Composer:
             delegator_address=delegator_address, validator_address=validator_address
         )
 
+    def MsgWithdrawValidatorCommission(
+        self, validator_address: str
+    ):      
+
+        return cosmos_distribution_tx_pb.MsgWithdrawValidatorCommission(
+            validator_address=validator_address
+        )
+
     def MsgVote(
         self,
         proposal_id: str,


### PR DESCRIPTION
Meant to enable a validator to withraw his commissions and not just the rewards.

The example file is very similar to [this one](https://github.com/InjectiveLabs/sdk-python/blob/master/examples/chain_client/26_MsgWithdrawDelegatorReward.py), the only difference being that two messages are packed into the tx (WithdrawRewards & WithdrawCommission) so that all available tokens are withdrawn at once.