### PR TITLE
Fix/cookie assistant for custom network

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ make tests
 * The Composer can still be instantiated without markets and tokens. When markets and tokens are not provided the Composer loads the required information from the Denoms used in previous versions
 * Change in AsyncClient to be able to create Composer instances for the client network, markets and tokens
 * Examples have been adapted to create Composer instances using the AsyncClient
+* Added new nodes (bare-metal load balancing nodes) for mainnet
+* Refactored the cookies management logic into a cookie assistant. Added the required logic to support the new cookies format for bare-metal load balanced nodes
 
 **0.7.1.1**
 * Fixed Testnet network URLs

--- a/pyinjective/core/network.py
+++ b/pyinjective/core/network.py
@@ -370,8 +370,9 @@ class Network:
             grpc_explorer_endpoint,
             chain_id,
             env,
-            cookie_assistant: CookieAssistant,
+            cookie_assistant: Optional[CookieAssistant] = None,
     ):
+        assistant = cookie_assistant or DisabledCookieAssistant()
         return cls(
             lcd_endpoint=lcd_endpoint,
             tm_websocket_endpoint=tm_websocket_endpoint,
@@ -381,7 +382,7 @@ class Network:
             chain_id=chain_id,
             fee_denom="inj",
             env=env,
-            cookie_assistant=cookie_assistant
+            cookie_assistant=assistant
         )
 
     def string(self):


### PR DESCRIPTION
- Change to have a default cookie assistant for custom networks, making the cookie-assistant parameter optional for the instance creation method