### PR TITLE
Feat/make bare metal lb default mainnet node

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ make tests
 ```
 
 ### Changelogs
+**0.8.1**
+* Moved the configuration to use a secure or insecure connection inside the Network class. The AsyncClient's `insecure` parameter is no longer used for anything and will be removed in the future.
+* Made the new load balanced bare-metal node the default one for mainnet (it is called `lb`). The legacy one (load balanced k8s node) is called `lb_k8s`
+
 **0.8**(change before release)
 * Refactor Composer to be created with all the markets and tokens. The Composer now uses the real markets and tokens to convert human-readable values to chain format
 * The Composer can still be instantiated without markets and tokens. When markets and tokens are not provided the Composer loads the required information from the Denoms used in previous versions

--- a/examples/chain_client/0_LocalOrderHash.py
+++ b/examples/chain_client/0_LocalOrderHash.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from pyinjective.async_client import AsyncClient
+from pyinjective.composer import Composer
 from pyinjective.transaction import Transaction
 from pyinjective.core.network import Network
 from pyinjective.wallet import PrivateKey
@@ -11,7 +12,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/13_MsgIncreasePositionMargin.py
+++ b/examples/chain_client/13_MsgIncreasePositionMargin.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/15_MsgWithdraw.py
+++ b/examples/chain_client/15_MsgWithdraw.py
@@ -25,7 +25,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/16_MsgSubaccountTransfer.py
+++ b/examples/chain_client/16_MsgSubaccountTransfer.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/17_MsgBatchUpdateOrders.py
+++ b/examples/chain_client/17_MsgBatchUpdateOrders.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/18_MsgBid.py
+++ b/examples/chain_client/18_MsgBid.py
@@ -10,7 +10,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/19_MsgGrant.py
+++ b/examples/chain_client/19_MsgGrant.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/1_MsgSend.py
+++ b/examples/chain_client/1_MsgSend.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/20_MsgExec.py
+++ b/examples/chain_client/20_MsgExec.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/21_MsgRevoke.py
+++ b/examples/chain_client/21_MsgRevoke.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/22_MsgSendToEth.py
+++ b/examples/chain_client/22_MsgSendToEth.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/23_MsgRelayPriceFeedPrice.py
+++ b/examples/chain_client/23_MsgRelayPriceFeedPrice.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/24_MsgRewardsOptOut.py
+++ b/examples/chain_client/24_MsgRewardsOptOut.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/25_MsgDelegate.py
+++ b/examples/chain_client/25_MsgDelegate.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/26_MsgWithdrawDelegatorReward.py
+++ b/examples/chain_client/26_MsgWithdrawDelegatorReward.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/27_Grants.py
+++ b/examples/chain_client/27_Grants.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     granter = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
     grantee = "inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r"
     msg_type_url = "/injective.exchange.v1beta1.MsgCreateDerivativeLimitOrder"

--- a/examples/chain_client/28_BankBalances.py
+++ b/examples/chain_client/28_BankBalances.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     address = "inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r"
     all_bank_balances = await client.get_bank_balances(address=address)
     print(all_bank_balances)

--- a/examples/chain_client/29_BankBalance.py
+++ b/examples/chain_client/29_BankBalance.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     address = "inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r"
     denom = "inj"
     bank_balance = await client.get_bank_balance(address=address, denom=denom)

--- a/examples/chain_client/2_MsgDeposit.py
+++ b/examples/chain_client/2_MsgDeposit.py
@@ -8,10 +8,10 @@ from pyinjective.wallet import PrivateKey
 
 async def main() -> None:
     # select network: local, testnet, mainnet
-    network = Network.testnet()
+    network = Network.testnet(node="sentry")
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/30_ExternalTransfer.py
+++ b/examples/chain_client/30_ExternalTransfer.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/31_MsgCreateBinaryOptionsLimitOrder.py
+++ b/examples/chain_client/31_MsgCreateBinaryOptionsLimitOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/32_MsgCreateBinaryOptionsMarketOrder.py
+++ b/examples/chain_client/32_MsgCreateBinaryOptionsMarketOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/33_MsgCancelBinaryOptionsOrder.py
+++ b/examples/chain_client/33_MsgCancelBinaryOptionsOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/34_MsgAdminUpdateBinaryOptionsMarket.py
+++ b/examples/chain_client/34_MsgAdminUpdateBinaryOptionsMarket.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/35_MsgInstantBinaryOptionsMarketLaunch.py
+++ b/examples/chain_client/35_MsgInstantBinaryOptionsMarketLaunch.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/36_MsgRelayProviderPrices.py
+++ b/examples/chain_client/36_MsgRelayProviderPrices.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/37_GetTx.py
+++ b/examples/chain_client/37_GetTx.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     tx_hash = "7746BC12EB82B4D59D036FBFF2F67BDCA6F62A20B3DBC25661707DD61D4DC1B7"
     tx_logs = await client.get_tx(tx_hash=tx_hash)
     print(tx_logs)

--- a/examples/chain_client/39_Account.py
+++ b/examples/chain_client/39_Account.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     address = "inj1knhahceyp57j5x7xh69p7utegnnnfgxavmahjr"
     acc = await client.get_account(address=address)
     print(acc)

--- a/examples/chain_client/3_MsgCreateSpotLimitOrder.py
+++ b/examples/chain_client/3_MsgCreateSpotLimitOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/40_MsgExecuteContract.py
+++ b/examples/chain_client/40_MsgExecuteContract.py
@@ -12,7 +12,7 @@ async def main() -> None:
 
     # initialize grpc client
     # set custom cookie location (optional) - defaults to current dir
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/41_MsgCreateInsuranceFund.py
+++ b/examples/chain_client/41_MsgCreateInsuranceFund.py
@@ -11,7 +11,7 @@ async def main() -> None:
 
     # initialize grpc client
     # set custom cookie location (optional) - defaults to current dir
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/42_MsgUnderwrite.py
+++ b/examples/chain_client/42_MsgUnderwrite.py
@@ -11,7 +11,7 @@ async def main() -> None:
 
     # initialize grpc client
     # set custom cookie location (optional) - defaults to current dir
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/43_MsgRequestRedemption.py
+++ b/examples/chain_client/43_MsgRequestRedemption.py
@@ -11,7 +11,7 @@ async def main() -> None:
 
     # initialize grpc client
     # set custom cookie location (optional) - defaults to current dir
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/44_MessageBroadcaster.py
+++ b/examples/chain_client/44_MessageBroadcaster.py
@@ -15,7 +15,6 @@ async def main() -> None:
     message_broadcaster = MsgBroadcasterWithPk.new_using_simulation(
         network=network,
         private_key=private_key_in_hexa,
-        use_secure_connection=True
     )
 
     priv_key = PrivateKey.from_hex(private_key_in_hexa)

--- a/examples/chain_client/45_MessageBroadcasterWithGranteeAccount.py
+++ b/examples/chain_client/45_MessageBroadcasterWithGranteeAccount.py
@@ -13,7 +13,7 @@ async def main() -> None:
     composer = ProtoMsgComposer(network=network.string())
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     await client.sync_timeout_height()
 
     # load account
@@ -25,7 +25,6 @@ async def main() -> None:
     message_broadcaster = MsgBroadcasterWithPk.new_for_grantee_account_using_simulation(
         network=network,
         grantee_private_key=private_key_in_hexa,
-        use_secure_connection=True
     )
 
     # prepare tx msg

--- a/examples/chain_client/46_MessageBroadcasterWithoutSimulation.py
+++ b/examples/chain_client/46_MessageBroadcasterWithoutSimulation.py
@@ -15,7 +15,6 @@ async def main() -> None:
     message_broadcaster = MsgBroadcasterWithPk.new_without_simulation(
         network=network,
         private_key=private_key_in_hexa,
-        use_secure_connection=True
     )
 
     priv_key = PrivateKey.from_hex(private_key_in_hexa)

--- a/examples/chain_client/47_MessageBroadcasterWithGranteeAccountWithoutSimulation.py
+++ b/examples/chain_client/47_MessageBroadcasterWithGranteeAccountWithoutSimulation.py
@@ -13,7 +13,7 @@ async def main() -> None:
     composer = ProtoMsgComposer(network=network.string())
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     await client.sync_timeout_height()
 
     # load account
@@ -25,7 +25,6 @@ async def main() -> None:
     message_broadcaster = MsgBroadcasterWithPk.new_for_grantee_account_without_simulation(
         network=network,
         grantee_private_key=private_key_in_hexa,
-        use_secure_connection=True
     )
 
     # prepare tx msg

--- a/examples/chain_client/4_MsgCreateSpotMarketOrder.py
+++ b/examples/chain_client/4_MsgCreateSpotMarketOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/5_MsgCancelSpotOrder.py
+++ b/examples/chain_client/5_MsgCancelSpotOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/6_MsgCreateDerivativeLimitOrder.py
+++ b/examples/chain_client/6_MsgCreateDerivativeLimitOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/7_MsgCreateDerivativeMarketOrder.py
+++ b/examples/chain_client/7_MsgCreateDerivativeMarketOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/chain_client/8_MsgCancelDerivativeOrder.py
+++ b/examples/chain_client/8_MsgCancelDerivativeOrder.py
@@ -11,7 +11,7 @@ async def main() -> None:
     network = Network.testnet()
 
     # initialize grpc client
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = await client.composer()
     await client.sync_timeout_height()
 

--- a/examples/exchange_client/accounts_rpc/1_StreamSubaccountBalance.py
+++ b/examples/exchange_client/accounts_rpc/1_StreamSubaccountBalance.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xc7dca7c15c364865f77a4fb67ab11dc95502e6fe000000000000000000000001"
     denoms = ["inj", "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"]
     subaccount = await client.stream_subaccount_balance(

--- a/examples/exchange_client/accounts_rpc/2_SubaccountBalance.py
+++ b/examples/exchange_client/accounts_rpc/2_SubaccountBalance.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     denom = "inj"
     balance = await client.get_subaccount_balance(

--- a/examples/exchange_client/accounts_rpc/3_SubaccountsList.py
+++ b/examples/exchange_client/accounts_rpc/3_SubaccountsList.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     account_address = "inj1clw20s2uxeyxtam6f7m84vgae92s9eh7vygagt"
     subacc_list = await client.get_subaccount_list(account_address)
     print(subacc_list)

--- a/examples/exchange_client/accounts_rpc/4_SubaccountBalancesList.py
+++ b/examples/exchange_client/accounts_rpc/4_SubaccountBalancesList.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     denoms = ["inj", "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"]
     subacc_balances_list = await client.get_subaccount_balances_list(

--- a/examples/exchange_client/accounts_rpc/5_SubaccountHistory.py
+++ b/examples/exchange_client/accounts_rpc/5_SubaccountHistory.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     denom = "inj"
     transfer_types = ["withdraw", "deposit"]

--- a/examples/exchange_client/accounts_rpc/6_SubaccountOrderSummary.py
+++ b/examples/exchange_client/accounts_rpc/6_SubaccountOrderSummary.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     order_direction = "buy"
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"

--- a/examples/exchange_client/accounts_rpc/7_OrderStates.py
+++ b/examples/exchange_client/accounts_rpc/7_OrderStates.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     spot_order_hashes = ["0xce0d9b701f77cd6ddfda5dd3a4fe7b2d53ba83e5d6c054fb2e9e886200b7b7bb", "0x2e2245b5431638d76c6e0cc6268970418a1b1b7df60a8e94b8cf37eae6105542"]
     derivative_order_hashes = ["0x82113f3998999bdc3892feaab2c4e53ba06c5fe887a2d5f9763397240f24da50", "0xbb1f036001378cecb5fff1cc69303919985b5bf058c32f37d5aaf9b804c07a06"]
     orders = await client.get_order_states(spot_order_hashes=spot_order_hashes, derivative_order_hashes=derivative_order_hashes)

--- a/examples/exchange_client/accounts_rpc/8_Portfolio.py
+++ b/examples/exchange_client/accounts_rpc/8_Portfolio.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     account_address = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
     portfolio = await client.get_portfolio(account_address=account_address)
     print(portfolio)

--- a/examples/exchange_client/accounts_rpc/9_Rewards.py
+++ b/examples/exchange_client/accounts_rpc/9_Rewards.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     # account_address = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
     epoch = -1
     rewards = await client.get_rewards(

--- a/examples/exchange_client/auctions_rpc/1_Auction.py
+++ b/examples/exchange_client/auctions_rpc/1_Auction.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     bid_round = 31
     auction = await client.get_auction(bid_round=bid_round)
     print(auction)

--- a/examples/exchange_client/auctions_rpc/2_Auctions.py
+++ b/examples/exchange_client/auctions_rpc/2_Auctions.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     auctions = await client.get_auctions()
     print(auctions)
 

--- a/examples/exchange_client/auctions_rpc/3_StreamBids.py
+++ b/examples/exchange_client/auctions_rpc/3_StreamBids.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     bids = await client.stream_bids()
     async for bid in bids:
         print(bid)

--- a/examples/exchange_client/derivative_exchange_rpc/10_StreamHistoricalOrders.py
+++ b/examples/exchange_client/derivative_exchange_rpc/10_StreamHistoricalOrders.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     order_side = "sell"
     subaccount_id = "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"

--- a/examples/exchange_client/derivative_exchange_rpc/11_Trades.py
+++ b/examples/exchange_client/derivative_exchange_rpc/11_Trades.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     subaccount_id = "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
     trades = await client.get_derivative_trades(

--- a/examples/exchange_client/derivative_exchange_rpc/12_StreamTrades.py
+++ b/examples/exchange_client/derivative_exchange_rpc/12_StreamTrades.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
         "0xd5e4b12b19ecf176e4e14b42944731c27677819d2ed93be4104ad7025529c7ff"

--- a/examples/exchange_client/derivative_exchange_rpc/13_SubaccountOrdersList.py
+++ b/examples/exchange_client/derivative_exchange_rpc/13_SubaccountOrdersList.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     skip = 1

--- a/examples/exchange_client/derivative_exchange_rpc/14_SubaccountTradesList.py
+++ b/examples/exchange_client/derivative_exchange_rpc/14_SubaccountTradesList.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     execution_type = "market"

--- a/examples/exchange_client/derivative_exchange_rpc/15_FundingPayments.py
+++ b/examples/exchange_client/derivative_exchange_rpc/15_FundingPayments.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     subaccount_id = "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"
     skip=0

--- a/examples/exchange_client/derivative_exchange_rpc/17_FundingRates.py
+++ b/examples/exchange_client/derivative_exchange_rpc/17_FundingRates.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     skip=0
     limit=3

--- a/examples/exchange_client/derivative_exchange_rpc/18_Orderbooks.py
+++ b/examples/exchange_client/derivative_exchange_rpc/18_Orderbooks.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
         "0xd5e4b12b19ecf176e4e14b42944731c27677819d2ed93be4104ad7025529c7ff"

--- a/examples/exchange_client/derivative_exchange_rpc/19_Binary_Options_Markets.py
+++ b/examples/exchange_client/derivative_exchange_rpc/19_Binary_Options_Markets.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_status = "active"
     quote_denom = "peggy0xdAC17F958D2ee523a2206206994597C13D831ec7"
     market = await client.get_binary_options_markets(

--- a/examples/exchange_client/derivative_exchange_rpc/1_Market.py
+++ b/examples/exchange_client/derivative_exchange_rpc/1_Market.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     market = await client.get_derivative_market(market_id=market_id)
     print(market)

--- a/examples/exchange_client/derivative_exchange_rpc/20_Binary_Options_Market.py
+++ b/examples/exchange_client/derivative_exchange_rpc/20_Binary_Options_Market.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x175513943b8677368d138e57bcd6bef53170a0da192e7eaa8c2cd4509b54f8db"
     market = await client.get_binary_options_market(market_id=market_id)
     print(market)

--- a/examples/exchange_client/derivative_exchange_rpc/21_Historical_Orders.py
+++ b/examples/exchange_client/derivative_exchange_rpc/21_Historical_Orders.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     subaccount_id = "0x295639d56c987f0e24d21bb167872b3542a6e05a000000000000000000000000"
     is_conditional = "false"

--- a/examples/exchange_client/derivative_exchange_rpc/22_OrderbooksV2.py
+++ b/examples/exchange_client/derivative_exchange_rpc/22_OrderbooksV2.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
         "0xd5e4b12b19ecf176e4e14b42944731c27677819d2ed93be4104ad7025529c7ff"

--- a/examples/exchange_client/derivative_exchange_rpc/2_Markets.py
+++ b/examples/exchange_client/derivative_exchange_rpc/2_Markets.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_status = "active"
     quote_denom = "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"
     market = await client.get_derivative_markets(

--- a/examples/exchange_client/derivative_exchange_rpc/3_StreamMarket.py
+++ b/examples/exchange_client/derivative_exchange_rpc/3_StreamMarket.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     markets = await client.stream_derivative_markets()
     async for market in markets:
         print(market)

--- a/examples/exchange_client/derivative_exchange_rpc/4_Orderbook.py
+++ b/examples/exchange_client/derivative_exchange_rpc/4_Orderbook.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     market = await client.get_derivative_orderbook(market_id=market_id)
     print(market)

--- a/examples/exchange_client/derivative_exchange_rpc/5_StreamOrderbooks.py
+++ b/examples/exchange_client/derivative_exchange_rpc/5_StreamOrderbooks.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     markets = await client.stream_derivative_orderbook_snapshot(market_ids=[market_id])
     async for market in markets:

--- a/examples/exchange_client/derivative_exchange_rpc/6_StreamOrderbookUpdate.py
+++ b/examples/exchange_client/derivative_exchange_rpc/6_StreamOrderbookUpdate.py
@@ -50,7 +50,7 @@ async def load_orderbook_snapshot(async_client: AsyncClient, orderbook: Orderboo
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    async_client = AsyncClient(network, insecure=False)
+    async_client = AsyncClient(network)
 
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     orderbook = Orderbook(market_id=market_id)

--- a/examples/exchange_client/derivative_exchange_rpc/7_Positions.py
+++ b/examples/exchange_client/derivative_exchange_rpc/7_Positions.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
         "0xd97d0da6f6c11710ef06315971250e4e9aed4b7d4cd02059c9477ec8cf243782"

--- a/examples/exchange_client/derivative_exchange_rpc/9_StreamPositions.py
+++ b/examples/exchange_client/derivative_exchange_rpc/9_StreamPositions.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
     subaccount_id = "0xea98e3aa091a6676194df40ac089e40ab4604bf9000000000000000000000000"
     positions = await client.stream_derivative_positions(

--- a/examples/exchange_client/explorer_rpc/10_GetIBCTransfers.py
+++ b/examples/exchange_client/explorer_rpc/10_GetIBCTransfers.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     sender = "inj1cll5cv3ezgal30gagkhnq2um6zf6qrmhw4r6c8"
     receiver = "cosmos1usr9g5a4s2qrwl63sdjtrs2qd4a7huh622pg82"
     src_channel = "channel-2"

--- a/examples/exchange_client/explorer_rpc/1_GetTxByHash.py
+++ b/examples/exchange_client/explorer_rpc/1_GetTxByHash.py
@@ -9,7 +9,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = Composer(network=network.string())
     tx_hash = "0F3EBEC1882E1EEAC5B7BDD836E976250F1CD072B79485877CEACCB92ACDDF52"
     transaction_response = await client.get_tx_by_hash(tx_hash=tx_hash)

--- a/examples/exchange_client/explorer_rpc/2_AccountTxs.py
+++ b/examples/exchange_client/explorer_rpc/2_AccountTxs.py
@@ -9,7 +9,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     composer = Composer(network=network.string())
     address = "inj1phd706jqzd9wznkk5hgsfkrc8jqxv0kmlj0kex"
     message_type = "cosmos.bank.v1beta1.MsgSend"

--- a/examples/exchange_client/explorer_rpc/3_Blocks.py
+++ b/examples/exchange_client/explorer_rpc/3_Blocks.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     limit = 2
     block = await client.get_blocks(limit=limit)
     print(block)

--- a/examples/exchange_client/explorer_rpc/4_Block.py
+++ b/examples/exchange_client/explorer_rpc/4_Block.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     block_height = "5825046"
     block = await client.get_block(block_height=block_height)
     print(block)

--- a/examples/exchange_client/explorer_rpc/5_TxsRequest.py
+++ b/examples/exchange_client/explorer_rpc/5_TxsRequest.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     limit = 2
     txs = await client.get_txs(limit=limit)
     print(txs)

--- a/examples/exchange_client/explorer_rpc/6_StreamTxs.py
+++ b/examples/exchange_client/explorer_rpc/6_StreamTxs.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     stream_txs = await client.stream_txs(
     )
     async for tx in stream_txs:

--- a/examples/exchange_client/explorer_rpc/7_StreamBlocks.py
+++ b/examples/exchange_client/explorer_rpc/7_StreamBlocks.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     stream_blocks = await client.stream_blocks(
     )
     async for block in stream_blocks:

--- a/examples/exchange_client/explorer_rpc/8_GetPeggyDeposits.py
+++ b/examples/exchange_client/explorer_rpc/8_GetPeggyDeposits.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     receiver = "inj1phd706jqzd9wznkk5hgsfkrc8jqxv0kmlj0kex"
     peggy_deposits = await client.get_peggy_deposits(receiver=receiver)
     print(peggy_deposits)

--- a/examples/exchange_client/explorer_rpc/9_GetPeggyWithdrawals.py
+++ b/examples/exchange_client/explorer_rpc/9_GetPeggyWithdrawals.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     sender = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
     limit = 2
     peggy_deposits = await client.get_peggy_withdrawals(

--- a/examples/exchange_client/insurance_rpc/1_InsuranceFunds.py
+++ b/examples/exchange_client/insurance_rpc/1_InsuranceFunds.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     insurance_funds = await client.get_insurance_funds()
     print(insurance_funds)
 

--- a/examples/exchange_client/insurance_rpc/2_Redemptions.py
+++ b/examples/exchange_client/insurance_rpc/2_Redemptions.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     redeemer = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
     redemption_denom = "share4"
     status = "disbursed"

--- a/examples/exchange_client/meta_rpc/1_Ping.py
+++ b/examples/exchange_client/meta_rpc/1_Ping.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     resp = await client.ping()
     print('Health OK?', resp)
 

--- a/examples/exchange_client/meta_rpc/2_Version.py
+++ b/examples/exchange_client/meta_rpc/2_Version.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     resp = await client.version()
     print('Version:', resp)
 

--- a/examples/exchange_client/meta_rpc/3_Info.py
+++ b/examples/exchange_client/meta_rpc/3_Info.py
@@ -9,7 +9,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     resp = await client.info()
     print('[!] Info:')
     print(resp)

--- a/examples/exchange_client/meta_rpc/4_StreamKeepAlive.py
+++ b/examples/exchange_client/meta_rpc/4_StreamKeepAlive.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
 
     task1 = asyncio.create_task(get_markets(client))
     task2 = asyncio.create_task(keepalive(client, [task1]))

--- a/examples/exchange_client/oracle_rpc/1_StreamPrices.py
+++ b/examples/exchange_client/oracle_rpc/1_StreamPrices.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     base_symbol = 'BTC'
     quote_symbol = 'USDT'
     oracle_type = 'bandibc'

--- a/examples/exchange_client/oracle_rpc/2_Price.py
+++ b/examples/exchange_client/oracle_rpc/2_Price.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     base_symbol = 'BTC'
     quote_symbol = 'USDT'
     oracle_type = 'bandibc'

--- a/examples/exchange_client/oracle_rpc/3_OracleList.py
+++ b/examples/exchange_client/oracle_rpc/3_OracleList.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     oracle_list = await client.get_oracle_list()
     print(oracle_list)
 

--- a/examples/exchange_client/portfolio_rpc/1_AccountPortfolio.py
+++ b/examples/exchange_client/portfolio_rpc/1_AccountPortfolio.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     account_address = "inj1clw20s2uxeyxtam6f7m84vgae92s9eh7vygagt"
     portfolio = await client.get_account_portfolio(
         account_address=account_address

--- a/examples/exchange_client/portfolio_rpc/2_StreamAccountPortfolio.py
+++ b/examples/exchange_client/portfolio_rpc/2_StreamAccountPortfolio.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     account_address = "inj1clw20s2uxeyxtam6f7m84vgae92s9eh7vygagt"
     updates = await client.stream_account_portfolio(account_address=account_address)
     async for update in updates:

--- a/examples/exchange_client/spot_exchange_rpc/10_StreamTrades.py
+++ b/examples/exchange_client/spot_exchange_rpc/10_StreamTrades.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
         "0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0"

--- a/examples/exchange_client/spot_exchange_rpc/11_SubaccountOrdersList.py
+++ b/examples/exchange_client/spot_exchange_rpc/11_SubaccountOrdersList.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xc7dca7c15c364865f77a4fb67ab11dc95502e6fe000000000000000000000001"
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     skip = 10

--- a/examples/exchange_client/spot_exchange_rpc/12_SubaccountTradesList.py
+++ b/examples/exchange_client/spot_exchange_rpc/12_SubaccountTradesList.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     subaccount_id = "0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000"
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     execution_type = "market"

--- a/examples/exchange_client/spot_exchange_rpc/13_StreamOrderbooks.py
+++ b/examples/exchange_client/spot_exchange_rpc/13_StreamOrderbooks.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
         "0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0"

--- a/examples/exchange_client/spot_exchange_rpc/14_Orderbooks.py
+++ b/examples/exchange_client/spot_exchange_rpc/14_Orderbooks.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = [
         "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
         "0x7a57e705bb4e09c88aecfc295569481dbf2fe1d5efe364651fbe72385938e9b0"

--- a/examples/exchange_client/spot_exchange_rpc/15_HistoricalOrders.py
+++ b/examples/exchange_client/spot_exchange_rpc/15_HistoricalOrders.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     subaccount_id = "0xbdaedec95d563fb05240d6e01821008454c24c36000000000000000000000000"
     skip = 10

--- a/examples/exchange_client/spot_exchange_rpc/1_Market.py
+++ b/examples/exchange_client/spot_exchange_rpc/1_Market.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     market = await client.get_spot_market(market_id=market_id)
     print(market)

--- a/examples/exchange_client/spot_exchange_rpc/2_Markets.py
+++ b/examples/exchange_client/spot_exchange_rpc/2_Markets.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_status = "active"
     base_denom = "inj"
     quote_denom = "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5"

--- a/examples/exchange_client/spot_exchange_rpc/3_StreamMarkets.py
+++ b/examples/exchange_client/spot_exchange_rpc/3_StreamMarkets.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     markets = await client.stream_spot_markets()
     async for market in markets:
         print(market)

--- a/examples/exchange_client/spot_exchange_rpc/4_Orderbook.py
+++ b/examples/exchange_client/spot_exchange_rpc/4_Orderbook.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     orderbook = await client.get_spot_orderbookV2(market_id=market_id)
     print(orderbook)

--- a/examples/exchange_client/spot_exchange_rpc/6_Trades.py
+++ b/examples/exchange_client/spot_exchange_rpc/6_Trades.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = ["0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"]
     execution_side = "taker"
     direction = "buy"

--- a/examples/exchange_client/spot_exchange_rpc/7_StreamOrderbookSnapshot.py
+++ b/examples/exchange_client/spot_exchange_rpc/7_StreamOrderbookSnapshot.py
@@ -8,7 +8,7 @@ from pyinjective.core.network import Network
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_ids = ["0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"]
     orderbooks = await client.stream_spot_orderbook_snapshot(market_ids=market_ids)
     async for orderbook in orderbooks:

--- a/examples/exchange_client/spot_exchange_rpc/8_StreamOrderbookUpdate.py
+++ b/examples/exchange_client/spot_exchange_rpc/8_StreamOrderbookUpdate.py
@@ -50,7 +50,7 @@ async def load_orderbook_snapshot(async_client: AsyncClient, orderbook: Orderboo
 async def main() -> None:
     # select network: local, testnet, mainnet
     network = Network.testnet()
-    async_client = AsyncClient(network, insecure=False)
+    async_client = AsyncClient(network)
 
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     orderbook = Orderbook(market_id=market_id)

--- a/examples/exchange_client/spot_exchange_rpc/9_StreamHistoricalOrders.py
+++ b/examples/exchange_client/spot_exchange_rpc/9_StreamHistoricalOrders.py
@@ -7,7 +7,7 @@ from pyinjective.core.network import Network
 
 async def main() -> None:
     network = Network.testnet()
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     market_id = "0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
     order_side = "buy"
     subaccount_id = "0xc6fe5d33615a1c52c08018c47e8bc53646a0e101000000000000000000000000"

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -78,6 +78,7 @@ class AsyncClient:
             insecure: bool = False,
             credentials=grpc.ssl_channel_credentials(),
     ):
+        # the `insecure` parameter is ignored and will be deprecated soon. The value is taken directly from `network`
 
         self.addr = ""
         self.number = 0
@@ -87,11 +88,11 @@ class AsyncClient:
 
         # chain stubs
         self.chain_channel = (
-            grpc.aio.insecure_channel(network.grpc_endpoint)
-            if (insecure or credentials is None)
-            else grpc.aio.secure_channel(network.grpc_endpoint, credentials)
+            grpc.aio.secure_channel(network.grpc_endpoint, credentials)
+            if (network.use_secure_connection and credentials is not None)
+            else grpc.aio.insecure_channel(network.grpc_endpoint)
         )
-        self.insecure = insecure
+
         self.stubCosmosTendermint = tendermint_query_grpc.ServiceStub(
             self.chain_channel
         )
@@ -105,9 +106,9 @@ class AsyncClient:
 
         # exchange stubs
         self.exchange_channel = (
-            grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-            if (insecure or credentials is None)
-            else grpc.aio.secure_channel(network.grpc_exchange_endpoint, credentials)
+            grpc.aio.secure_channel(network.grpc_exchange_endpoint, credentials)
+            if (network.use_secure_connection and credentials is not None)
+            else grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
         )
         self.stubMeta = exchange_meta_rpc_grpc.InjectiveMetaRPCStub(
             self.exchange_channel
@@ -136,9 +137,9 @@ class AsyncClient:
 
         # explorer stubs
         self.explorer_channel = (
-            grpc.aio.insecure_channel(network.grpc_explorer_endpoint)
-            if (insecure or credentials is None)
-            else grpc.aio.secure_channel(network.grpc_explorer_endpoint, credentials)
+            grpc.aio.secure_channel(network.grpc_explorer_endpoint, credentials)
+            if (network.use_secure_connection and credentials is not None)
+            else grpc.aio.insecure_channel(network.grpc_explorer_endpoint)
         )
         self.stubExplorer = explorer_rpc_grpc.InjectiveExplorerRPCStub(
             self.explorer_channel

--- a/pyinjective/core/broadcaster.py
+++ b/pyinjective/core/broadcaster.py
@@ -67,11 +67,10 @@ class MsgBroadcasterWithPk:
             cls,
             network: Network,
             private_key: str,
-            use_secure_connection: bool = True,
             client: Optional[AsyncClient] = None,
             composer: Optional[Composer] = None,
     ):
-        client = client or AsyncClient(network=network, insecure=not(use_secure_connection))
+        client = client or AsyncClient(network=network)
         composer = composer or Composer(network=client.network.string())
         account_config = StandardAccountBroadcasterConfig(private_key=private_key)
         fee_calculator = SimulatedTransactionFeeCalculator(
@@ -92,11 +91,10 @@ class MsgBroadcasterWithPk:
             cls,
             network: Network,
             private_key: str,
-            use_secure_connection: bool = True,
             client: Optional[AsyncClient] = None,
             composer: Optional[Composer] = None,
     ):
-        client = client or AsyncClient(network=network, insecure=not (use_secure_connection))
+        client = client or AsyncClient(network=network)
         composer = composer or Composer(network=client.network.string())
         account_config = StandardAccountBroadcasterConfig(private_key=private_key)
         fee_calculator = MessageBasedTransactionFeeCalculator(
@@ -117,11 +115,10 @@ class MsgBroadcasterWithPk:
             cls,
             network: Network,
             grantee_private_key: str,
-            use_secure_connection: bool = True,
             client: Optional[AsyncClient] = None,
             composer: Optional[Composer] = None,
     ):
-        client = client or AsyncClient(network=network, insecure=not (use_secure_connection))
+        client = client or AsyncClient(network=network)
         composer = composer or Composer(network=client.network.string())
         account_config = GranteeAccountBroadcasterConfig(grantee_private_key=grantee_private_key, composer=composer)
         fee_calculator = SimulatedTransactionFeeCalculator(
@@ -142,11 +139,10 @@ class MsgBroadcasterWithPk:
             cls,
             network: Network,
             grantee_private_key: str,
-            use_secure_connection: bool = True,
             client: Optional[AsyncClient] = None,
             composer: Optional[Composer] = None,
     ):
-        client = client or AsyncClient(network=network, insecure=not (use_secure_connection))
+        client = client or AsyncClient(network=network)
         composer = composer or Composer(network=client.network.string())
         account_config = GranteeAccountBroadcasterConfig(grantee_private_key=grantee_private_key, composer=composer)
         fee_calculator = MessageBasedTransactionFeeCalculator(

--- a/pyinjective/utils/fetch_metadata.py
+++ b/pyinjective/utils/fetch_metadata.py
@@ -28,7 +28,7 @@ async def fetch_denom(network) -> str:
     symbols = {}
 
     # fetch meta data for spot markets
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     status = 'active'
     mresp = await client.get_spot_markets(market_status=status)
     for market in mresp.markets:
@@ -55,7 +55,7 @@ async def fetch_denom(network) -> str:
         denom_output += config
 
     # fetch meta data for derivative markets
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     status = 'active'
     mresp = await client.get_derivative_markets(market_status=status)
     for market in mresp.markets:

--- a/pyinjective/utils/metadata_validation.py
+++ b/pyinjective/utils/metadata_validation.py
@@ -4,12 +4,12 @@ from typing import Any, List, Tuple
 
 import pyinjective.constant as constant
 from pyinjective.async_client import AsyncClient
-from pyinjective.constant import Network
+from pyinjective.core.network import Network
 from pyinjective.core.market import SpotMarket, DerivativeMarket, BinaryOptionMarket
 
 
 def find_metadata_inconsistencies(network: Network) -> Tuple[List[Any]]:
-    client = AsyncClient(network, insecure=False)
+    client = AsyncClient(network)
     ini_config = constant.CONFIGS[network.string()]
 
     spot_markets = asyncio.get_event_loop().run_until_complete(client.all_spot_markets())

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ URL = "https://github.com/InjectiveLabs/sdk-python"
 EMAIL = "achilleas@injectivelabs.com"
 AUTHOR = "Injective Labs"
 REQUIRES_PYTHON = ">=3.9"
-VERSION = "0.8"
+VERSION = "0.8.1"
 
 REQUIRED = [
     "aiohttp",

--- a/tests/core/test_message_based_transaction_fee_calculator.py
+++ b/tests/core/test_message_based_transaction_fee_calculator.py
@@ -18,7 +18,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_privileged_execute_contract_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -40,7 +40,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_execute_contract_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -66,7 +66,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_wasm_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -88,7 +88,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_governance_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -110,7 +110,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_exchange_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -141,7 +141,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_msg_exec_message(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,
@@ -180,7 +180,7 @@ class TestMessageBasedTransactionFeeCalculator:
     @pytest.mark.asyncio
     async def test_gas_fee_for_two_messages_in_one_transaction(self):
         network = Network.testnet(node="sentry")
-        client = AsyncClient(network=network, insecure=False)
+        client = AsyncClient(network=network)
         composer = Composer(network=network.string())
         calculator = MessageBasedTransactionFeeCalculator(
             client=client,


### PR DESCRIPTION
- Moved the configuration to use a secure or insecure connection inside the Network class. The AsyncClient's `insecure` parameter is no longer used for anything and will be removed in the future.
- Made the new load balanced bare-metal node the default one for mainnet (it is called `lb`). The legacy one (load balanced k8s node) is called `lb_k8s`
- Fixed an issue with the cookies manager configuration for the testnet `sentry` node