### PR TITLE
feat/reduce_calls_for_cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added support for all queries in the chain 'tendermint' module
 
+### Changed
+- Refactored cookies management logic to use all gRPC calls' responses to update the current cookies
+
 ## [1.4.1] - 2024-03-12
 ### Changed
 - Updates example scripts that were still using deprecated methods

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -3,7 +3,7 @@ import base64
 import time
 from copy import deepcopy
 from decimal import Decimal
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from warnings import warn
 
 import grpc
@@ -3206,18 +3206,6 @@ class AsyncClient:
             tokens_by_symbol[unique_symbol] = token
 
         return tokens_by_denom[denom]
-
-    def _chain_cookie_metadata_requestor(self) -> Coroutine:
-        request = tendermint_query.GetLatestBlockRequest()
-        return self.stubCosmosTendermint.GetLatestBlock(request).initial_metadata()
-
-    def _exchange_cookie_metadata_requestor(self) -> Coroutine:
-        request = exchange_meta_rpc_pb.VersionRequest()
-        return self.stubMeta.Version(request).initial_metadata()
-
-    def _explorer_cookie_metadata_requestor(self) -> Coroutine:
-        request = explorer_rpc_pb.GetBlocksRequest()
-        return self.stubExplorer.GetBlocks(request).initial_metadata()
 
     def _initialize_timeout_height_sync_task(self):
         self._cancel_timeout_height_sync_task()

--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -166,169 +166,115 @@ class AsyncClient:
 
         self.bank_api = ChainGrpcBankApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.auth_api = ChainGrpcAuthApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.authz_api = ChainGrpcAuthZApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.distribution_api = ChainGrpcDistributionApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.chain_exchange_api = ChainGrpcExchangeApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.tendermint_api = TendermintGrpcApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.token_factory_api = ChainGrpcTokenFactoryApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.tx_api = TxGrpcApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
         self.wasm_api = ChainGrpcWasmApi(
             channel=self.chain_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
 
         self.chain_stream_api = ChainGrpcChainStream(
             channel=self.chain_stream_channel,
-            metadata_provider=lambda: self.network.chain_metadata(
-                metadata_query_provider=self._chain_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.chain_cookie_assistant,
         )
 
         self.exchange_account_api = IndexerGrpcAccountApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_auction_api = IndexerGrpcAuctionApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_derivative_api = IndexerGrpcDerivativeApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_insurance_api = IndexerGrpcInsuranceApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_meta_api = IndexerGrpcMetaApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_oracle_api = IndexerGrpcOracleApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_portfolio_api = IndexerGrpcPortfolioApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_spot_api = IndexerGrpcSpotApi(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
 
         self.exchange_account_stream_api = IndexerGrpcAccountStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_auction_stream_api = IndexerGrpcAuctionStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_derivative_stream_api = IndexerGrpcDerivativeStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_meta_stream_api = IndexerGrpcMetaStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_oracle_stream_api = IndexerGrpcOracleStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_portfolio_stream_api = IndexerGrpcPortfolioStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
         self.exchange_spot_stream_api = IndexerGrpcSpotStream(
             channel=self.exchange_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._exchange_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.exchange_cookie_assistant,
         )
 
         self.exchange_explorer_api = IndexerGrpcExplorerApi(
             channel=self.explorer_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._explorer_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.explorer_cookie_assistant,
         )
         self.exchange_explorer_stream_api = IndexerGrpcExplorerStream(
             channel=self.explorer_channel,
-            metadata_provider=lambda: self.network.exchange_metadata(
-                metadata_query_provider=self._explorer_cookie_metadata_requestor
-            ),
+            cookie_assistant=network.explorer_cookie_assistant,
         )
 
     async def all_tokens(self) -> Dict[str, Token]:
@@ -404,7 +350,7 @@ class AsyncClient:
         warn("This method is deprecated. Use fetch_account instead", DeprecationWarning, stacklevel=2)
 
         try:
-            metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+            metadata = self.network.chain_cookie_assistant.metadata()
             account_any = (
                 await self.stubAuth.Account(auth_query.QueryAccountRequest(address=address), metadata=metadata)
             ).account
@@ -460,7 +406,7 @@ class AsyncClient:
         warn("This method is deprecated. Use simulate instead", DeprecationWarning, stacklevel=2)
         try:
             req = tx_service.SimulateRequest(tx_bytes=tx_byte)
-            metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+            metadata = self.network.chain_cookie_assistant.metadata()
             return await self.stubTx.Simulate(request=req, metadata=metadata), True
         except grpc.RpcError as err:
             return err, False
@@ -474,7 +420,7 @@ class AsyncClient:
         """
         warn("This method is deprecated. Use broadcast_tx_sync_mode instead", DeprecationWarning, stacklevel=2)
         req = tx_service.BroadcastTxRequest(tx_bytes=tx_byte, mode=tx_service.BroadcastMode.BROADCAST_MODE_SYNC)
-        metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+        metadata = self.network.chain_cookie_assistant.metadata()
         result = await self.stubTx.BroadcastTx(request=req, metadata=metadata)
         return result.tx_response
 
@@ -487,7 +433,7 @@ class AsyncClient:
         """
         warn("This method is deprecated. Use broadcast_tx_async_mode instead", DeprecationWarning, stacklevel=2)
         req = tx_service.BroadcastTxRequest(tx_bytes=tx_byte, mode=tx_service.BroadcastMode.BROADCAST_MODE_ASYNC)
-        metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+        metadata = self.network.chain_cookie_assistant.metadata()
         result = await self.stubTx.BroadcastTx(request=req, metadata=metadata)
         return result.tx_response
 
@@ -500,7 +446,7 @@ class AsyncClient:
         """
         warn("This method is deprecated. BLOCK broadcast mode should not be used", DeprecationWarning, stacklevel=2)
         req = tx_service.BroadcastTxRequest(tx_bytes=tx_byte, mode=tx_service.BroadcastMode.BROADCAST_MODE_BLOCK)
-        metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+        metadata = self.network.chain_cookie_assistant.metadata()
         result = await self.stubTx.BroadcastTx(request=req, metadata=metadata)
         return result.tx_response
 
@@ -1838,9 +1784,7 @@ class AsyncClient:
         warn("This method is deprecated. Use listen_spot_markets_updates instead", DeprecationWarning, stacklevel=2)
 
         req = spot_exchange_rpc_pb.StreamMarketsRequest(market_ids=kwargs.get("market_ids"))
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamMarkets(request=req, metadata=metadata)
 
     async def listen_spot_markets_updates(
@@ -2030,9 +1974,7 @@ class AsyncClient:
         """
         warn("This method is deprecated. Use listen_spot_orderbook_snapshots instead", DeprecationWarning, stacklevel=2)
         req = spot_exchange_rpc_pb.StreamOrderbookV2Request(market_ids=market_ids)
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamOrderbookV2(request=req, metadata=metadata)
 
     async def listen_spot_orderbook_snapshots(
@@ -2055,9 +1997,7 @@ class AsyncClient:
         """
         warn("This method is deprecated. Use listen_spot_orderbook_updates instead", DeprecationWarning, stacklevel=2)
         req = spot_exchange_rpc_pb.StreamOrderbookUpdateRequest(market_ids=market_ids)
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamOrderbookUpdate(request=req, metadata=metadata)
 
     async def listen_spot_orderbook_updates(
@@ -2093,9 +2033,7 @@ class AsyncClient:
             trade_id=kwargs.get("trade_id"),
             cid=kwargs.get("cid"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamOrders(request=req, metadata=metadata)
 
     async def listen_spot_orders_updates(
@@ -2143,9 +2081,7 @@ class AsyncClient:
             state=kwargs.get("state"),
             execution_types=kwargs.get("execution_types"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamOrdersHistory(request=req, metadata=metadata)
 
     async def listen_spot_orders_history_updates(
@@ -2190,9 +2126,7 @@ class AsyncClient:
             state=kwargs.get("state"),
             execution_types=kwargs.get("execution_types"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamOrdersHistory(request=req, metadata=metadata)
 
     async def listen_derivative_orders_history_updates(
@@ -2240,9 +2174,7 @@ class AsyncClient:
             account_address=kwargs.get("account_address"),
             cid=kwargs.get("cid"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubSpotExchange.StreamTrades(request=req, metadata=metadata)
 
     async def listen_spot_trades_updates(
@@ -2375,9 +2307,7 @@ class AsyncClient:
             "This method is deprecated. Use listen_derivative_market_updates instead", DeprecationWarning, stacklevel=2
         )
         req = derivative_exchange_rpc_pb.StreamMarketRequest(market_ids=kwargs.get("market_ids"))
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamMarket(request=req, metadata=metadata)
 
     async def listen_derivative_market_updates(
@@ -2580,9 +2510,7 @@ class AsyncClient:
             stacklevel=2,
         )
         req = derivative_exchange_rpc_pb.StreamOrderbookV2Request(market_ids=market_ids)
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamOrderbookV2(request=req, metadata=metadata)
 
     async def listen_derivative_orderbook_snapshots(
@@ -2609,9 +2537,7 @@ class AsyncClient:
             stacklevel=2,
         )
         req = derivative_exchange_rpc_pb.StreamOrderbookUpdateRequest(market_ids=market_ids)
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamOrderbookUpdate(request=req, metadata=metadata)
 
     async def listen_derivative_orderbook_updates(
@@ -2651,9 +2577,7 @@ class AsyncClient:
             trade_id=kwargs.get("trade_id"),
             cid=kwargs.get("cid"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamOrders(request=req, metadata=metadata)
 
     async def listen_derivative_orders_updates(
@@ -2711,9 +2635,7 @@ class AsyncClient:
             account_address=kwargs.get("account_address"),
             cid=kwargs.get("cid"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamTrades(request=req, metadata=metadata)
 
     async def listen_derivative_trades_updates(
@@ -2793,9 +2715,7 @@ class AsyncClient:
             subaccount_id=kwargs.get("subaccount_id"),
             subaccount_ids=kwargs.get("subaccount_ids"),
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubDerivativeExchange.StreamPositions(request=req, metadata=metadata)
 
     async def listen_derivative_positions_updates(
@@ -3008,9 +2928,7 @@ class AsyncClient:
         req = portfolio_rpc_pb.StreamAccountPortfolioRequest(
             account_address=account_address, subaccount_id=kwargs.get("subaccount_id"), type=kwargs.get("type")
         )
-        metadata = await self.network.exchange_metadata(
-            metadata_query_provider=self._exchange_cookie_metadata_requestor
-        )
+        metadata = self.network.exchange_cookie_assistant.metadata()
         return self.stubPortfolio.StreamAccountPortfolio(request=req, metadata=metadata)
 
     async def listen_account_portfolio_updates(
@@ -3060,7 +2978,7 @@ class AsyncClient:
             positions_filter=positions_filter,
             oracle_price_filter=oracle_price_filter,
         )
-        metadata = await self.network.chain_metadata(metadata_query_provider=self._chain_cookie_metadata_requestor)
+        metadata = self.network.chain_cookie_assistant.metadata()
         return self.chain_stream_stub.Stream(request=request, metadata=metadata)
 
     async def listen_chain_stream_updates(

--- a/pyinjective/client/chain/grpc/chain_grpc_auction_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_auction_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.injective.auction.v1beta1 import (
     query_pb2 as auction_query_pb,
     query_pb2_grpc as auction_query_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcAuctionApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = auction_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = auction_query_pb.QueryAuctionParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_auth_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_auth_api.py
@@ -3,14 +3,15 @@ from typing import Any, Callable, Dict
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.auth.v1beta1 import query_pb2 as auth_query_pb, query_pb2_grpc as auth_query_grpc
 from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcAuthApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = auth_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = auth_query_pb.QueryParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_authz_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_authz_api.py
@@ -3,14 +3,15 @@ from typing import Any, Callable, Dict, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.authz.v1beta1 import query_pb2 as authz_query, query_pb2_grpc as authz_query_grpc
 from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcAuthZApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = authz_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_grants(
         self,

--- a/pyinjective/client/chain/grpc/chain_grpc_bank_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_bank_api.py
@@ -3,14 +3,15 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.bank.v1beta1 import query_pb2 as bank_query_pb, query_pb2_grpc as bank_query_grpc
 from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcBankApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = bank_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = bank_query_pb.QueryParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_distribution_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_distribution_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.distribution.v1beta1 import (
     query_pb2 as distribution_query_pb,
     query_pb2_grpc as distribution_query_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcDistributionApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = distribution_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = distribution_query_pb.QueryParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_exchange_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_exchange_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.injective.exchange.v1beta1 import (
     query_pb2 as exchange_query_pb,
     query_pb2_grpc as exchange_query_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcExchangeApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = exchange_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_exchange_params(self) -> Dict[str, Any]:
         request = exchange_query_pb.QueryExchangeParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_token_factory_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_token_factory_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.injective.tokenfactory.v1beta1 import (
     query_pb2 as token_factory_query_pb,
     query_pb2_grpc as token_factory_query_grpc,
@@ -11,10 +12,10 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcTokenFactoryApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._query_stub = token_factory_query_grpc.QueryStub(channel)
         self._tx_stub = token_factory_tx_grpc.MsgStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = token_factory_query_pb.QueryParamsRequest()

--- a/pyinjective/client/chain/grpc/chain_grpc_wasm_api.py
+++ b/pyinjective/client/chain/grpc/chain_grpc_wasm_api.py
@@ -3,14 +3,15 @@ from typing import Any, Callable, Dict, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmwasm.wasm.v1 import query_pb2 as wasm_query_pb, query_pb2_grpc as wasm_query_grpc
 from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class ChainGrpcWasmApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = wasm_query_grpc.QueryStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_module_params(self) -> Dict[str, Any]:
         request = wasm_query_pb.QueryParamsRequest()

--- a/pyinjective/client/chain/grpc_stream/chain_grpc_chain_stream.py
+++ b/pyinjective/client/chain/grpc_stream/chain_grpc_chain_stream.py
@@ -2,14 +2,15 @@ from typing import Callable, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.injective.stream.v1beta1 import query_pb2 as chain_stream_pb, query_pb2_grpc as chain_stream_grpc
 from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class ChainGrpcChainStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = chain_stream_grpc.StreamStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream(
         self,

--- a/pyinjective/client/indexer/grpc/indexer_grpc_account_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_account_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_accounts_rpc_pb2 as exchange_accounts_pb,
     injective_accounts_rpc_pb2_grpc as exchange_accounts_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcAccountApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_accounts_grpc.InjectiveAccountsRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_portfolio(self, account_address: str) -> Dict[str, Any]:
         request = exchange_accounts_pb.PortfolioRequest(account_address=account_address)

--- a/pyinjective/client/indexer/grpc/indexer_grpc_auction_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_auction_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_auction_rpc_pb2 as exchange_auction_pb,
     injective_auction_rpc_pb2_grpc as exchange_auction_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcAuctionApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_auction_grpc.InjectiveAuctionRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_auction(self, round: int) -> Dict[str, Any]:
         request = exchange_auction_pb.AuctionEndpointRequest(round=round)

--- a/pyinjective/client/indexer/grpc/indexer_grpc_derivative_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_derivative_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_derivative_exchange_rpc_pb2 as exchange_derivative_pb,
     injective_derivative_exchange_rpc_pb2_grpc as exchange_derivative_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcDerivativeApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_derivative_grpc.InjectiveDerivativeExchangeRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_markets(
         self,

--- a/pyinjective/client/indexer/grpc/indexer_grpc_explorer_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_explorer_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_explorer_rpc_pb2 as exchange_explorer_pb,
     injective_explorer_rpc_pb2_grpc as exchange_explorer_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcExplorerApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_explorer_grpc.InjectiveExplorerRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_account_txs(
         self,

--- a/pyinjective/client/indexer/grpc/indexer_grpc_insurance_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_insurance_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_insurance_rpc_pb2 as exchange_insurance_pb,
     injective_insurance_rpc_pb2_grpc as exchange_insurance_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcInsuranceApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_insurance_grpc.InjectiveInsuranceRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_insurance_funds(self) -> Dict[str, Any]:
         request = exchange_insurance_pb.FundsRequest()

--- a/pyinjective/client/indexer/grpc/indexer_grpc_meta_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_meta_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_meta_rpc_pb2 as exchange_meta_pb,
     injective_meta_rpc_pb2_grpc as exchange_meta_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcMetaApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_meta_grpc.InjectiveMetaRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_ping(self) -> Dict[str, Any]:
         request = exchange_meta_pb.PingRequest()

--- a/pyinjective/client/indexer/grpc/indexer_grpc_oracle_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_oracle_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_oracle_rpc_pb2 as exchange_oracle_pb,
     injective_oracle_rpc_pb2_grpc as exchange_oracle_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcOracleApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_oracle_grpc.InjectiveOracleRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_oracle_list(self) -> Dict[str, Any]:
         request = exchange_oracle_pb.OracleListRequest()

--- a/pyinjective/client/indexer/grpc/indexer_grpc_portfolio_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_portfolio_api.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, Dict
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_portfolio_rpc_pb2 as exchange_portfolio_pb,
     injective_portfolio_rpc_pb2_grpc as exchange_portfolio_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcPortfolioApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_portfolio_grpc.InjectivePortfolioRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_account_portfolio(self, account_address: str) -> Dict[str, Any]:
         request = exchange_portfolio_pb.AccountPortfolioRequest(account_address=account_address)

--- a/pyinjective/client/indexer/grpc/indexer_grpc_spot_api.py
+++ b/pyinjective/client/indexer/grpc/indexer_grpc_spot_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_spot_exchange_rpc_pb2 as exchange_spot_pb,
     injective_spot_exchange_rpc_pb2_grpc as exchange_spot_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class IndexerGrpcSpotApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_spot_grpc.InjectiveSpotExchangeRPCStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_markets(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_account_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_account_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, List, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_accounts_rpc_pb2 as exchange_accounts_pb,
     injective_accounts_rpc_pb2_grpc as exchange_accounts_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcAccountStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_accounts_grpc.InjectiveAccountsRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_subaccount_balance(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_auction_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_auction_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_auction_rpc_pb2 as exchange_auction_pb,
     injective_auction_rpc_pb2_grpc as exchange_auction_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcAuctionStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_auction_grpc.InjectiveAuctionRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_bids(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_derivative_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_derivative_stream.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_derivative_exchange_rpc_pb2 as exchange_derivative_pb,
     injective_derivative_exchange_rpc_pb2_grpc as exchange_derivative_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcDerivativeStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_derivative_grpc.InjectiveDerivativeExchangeRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_market(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_explorer_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_explorer_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_explorer_rpc_pb2 as exchange_explorer_pb,
     injective_explorer_rpc_pb2_grpc as exchange_explorer_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcExplorerStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_explorer_grpc.InjectiveExplorerRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_txs(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_meta_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_meta_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_meta_rpc_pb2 as exchange_meta_pb,
     injective_meta_rpc_pb2_grpc as exchange_meta_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcMetaStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_meta_grpc.InjectiveMetaRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_keepalive(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_oracle_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_oracle_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, List, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_oracle_rpc_pb2 as exchange_oracle_pb,
     injective_oracle_rpc_pb2_grpc as exchange_oracle_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcOracleStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_oracle_grpc.InjectiveOracleRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_oracle_prices(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_portfolio_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_portfolio_stream.py
@@ -2,6 +2,7 @@ from typing import Callable, Optional
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_portfolio_rpc_pb2 as exchange_portfolio_pb,
     injective_portfolio_rpc_pb2_grpc as exchange_portfolio_grpc,
@@ -10,9 +11,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcPortfolioStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_portfolio_grpc.InjectivePortfolioRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_account_portfolio(
         self,

--- a/pyinjective/client/indexer/grpc_stream/indexer_grpc_spot_stream.py
+++ b/pyinjective/client/indexer/grpc_stream/indexer_grpc_spot_stream.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.exchange import (
     injective_spot_exchange_rpc_pb2 as exchange_spot_pb,
     injective_spot_exchange_rpc_pb2_grpc as exchange_spot_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_stream_assistant import GrpcApiStreamAssistant
 
 
 class IndexerGrpcSpotStream:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = self._stub = exchange_spot_grpc.InjectiveSpotExchangeRPCStub(channel)
-        self._assistant = GrpcApiStreamAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiStreamAssistant(cookie_assistant=cookie_assistant)
 
     async def stream_markets(
         self,

--- a/pyinjective/core/network.py
+++ b/pyinjective/core/network.py
@@ -1,171 +1,103 @@
-import asyncio
 import datetime
-import time
 from abc import ABC, abstractmethod
 from http.cookies import SimpleCookie
-from typing import Callable, Optional, Tuple
+from typing import List, Optional
+
+from grpc.aio import Call, Metadata
 
 
 class CookieAssistant(ABC):
-    SESSION_RENEWAL_OFFSET = 120
-
     @abstractmethod
-    async def chain_cookie(self, metadata_query_provider: Callable) -> str:
+    def cookie(self) -> Optional[str]:
         ...
 
     @abstractmethod
-    async def exchange_cookie(self, metadata_query_provider: Callable) -> str:
+    async def process_response_metadata(self, grpc_call: Call):
         ...
 
-    async def chain_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
-        cookie = await self.chain_cookie(metadata_query_provider=metadata_query_provider)
-        return (("cookie", cookie),)
-
-    async def exchange_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
-        cookie = await self.exchange_cookie(metadata_query_provider=metadata_query_provider)
-        metadata = None
+    def metadata(self) -> Metadata:
+        cookie = self.cookie()
+        metadata = Metadata()
         if cookie is not None and cookie != "":
-            metadata = (("cookie", cookie),)
+            metadata.add("cookie", cookie)
         return metadata
-
-
-class KubernetesLoadBalancedCookieAssistant(CookieAssistant):
-    def __init__(self):
-        self._chain_cookie: Optional[str] = None
-        self._exchange_cookie: Optional[str] = None
-        self._chain_cookie_initialization_lock = asyncio.Lock()
-        self._exchange_cookie_initialization_lock = asyncio.Lock()
-
-    async def chain_cookie(self, metadata_query_provider: Callable) -> str:
-        if self._chain_cookie is None:
-            async with self._chain_cookie_initialization_lock:
-                if self._chain_cookie is None:
-                    await self._fetch_chain_cookie(metadata_query_provider=metadata_query_provider)
-        cookie = self._chain_cookie
-        self._check_chain_cookie_expiration()
-
-        return cookie
-
-    async def exchange_cookie(self, metadata_query_provider: Callable) -> str:
-        if self._exchange_cookie is None:
-            async with self._exchange_cookie_initialization_lock:
-                if self._exchange_cookie is None:
-                    await self._fetch_exchange_cookie(metadata_query_provider=metadata_query_provider)
-        cookie = self._exchange_cookie
-        self._check_exchange_cookie_expiration()
-
-        return cookie
-
-    async def _fetch_chain_cookie(self, metadata_query_provider: Callable):
-        metadata = await metadata_query_provider()
-        cookie_info = next((value for key, value in metadata if key == "set-cookie"), None)
-
-        if cookie_info is None:
-            raise RuntimeError(f"Error fetching chain cookie ({metadata})")
-
-        self._chain_cookie = cookie_info
-
-    async def _fetch_exchange_cookie(self, metadata_query_provider: Callable):
-        metadata = await metadata_query_provider()
-        cookie_info = next((value for key, value in metadata if key == "set-cookie"), None)
-
-        if cookie_info is None:
-            cookie_info = ""
-
-        self._exchange_cookie = cookie_info
-
-    def _check_chain_cookie_expiration(self):
-        if self._is_cookie_expired(cookie_data=self._chain_cookie):
-            self._chain_cookie = None
-
-    def _check_exchange_cookie_expiration(self):
-        if self._is_cookie_expired(cookie_data=self._exchange_cookie):
-            self._exchange_cookie = None
-
-    def _is_cookie_expired(self, cookie_data: str) -> bool:
-        cookie = SimpleCookie()
-        cookie.load(cookie_data)
-
-        expiration_data: Optional[str] = cookie.get("GCLB", {}).get("expires", None)
-        if expiration_data is None:
-            expiration_time = 0
-        else:
-            expiration_time = datetime.datetime.strptime(expiration_data, "%a, %d-%b-%Y %H:%M:%S %Z").timestamp()
-
-        timestamp_diff = expiration_time - time.time()
-        return timestamp_diff < self.SESSION_RENEWAL_OFFSET
 
 
 class BareMetalLoadBalancedCookieAssistant(CookieAssistant):
     def __init__(self):
-        self._chain_cookie: Optional[str] = None
-        self._exchange_cookie: Optional[str] = None
-        self._chain_cookie_initialization_lock = asyncio.Lock()
-        self._exchange_cookie_initialization_lock = asyncio.Lock()
+        self._cookie: Optional[str] = None
 
-    async def chain_cookie(self, metadata_query_provider: Callable) -> str:
-        if self._chain_cookie is None:
-            async with self._chain_cookie_initialization_lock:
-                if self._chain_cookie is None:
-                    await self._fetch_chain_cookie(metadata_query_provider=metadata_query_provider)
-        cookie = self._chain_cookie
-        self._check_chain_cookie_expiration()
+    def cookie(self) -> Optional[str]:
+        self._check_cookie_expiration()
 
-        return cookie
+        return self._cookie
 
-    async def exchange_cookie(self, metadata_query_provider: Callable) -> str:
-        if self._exchange_cookie is None:
-            async with self._exchange_cookie_initialization_lock:
-                if self._exchange_cookie is None:
-                    await self._fetch_exchange_cookie(metadata_query_provider=metadata_query_provider)
-        cookie = self._exchange_cookie
-        self._check_exchange_cookie_expiration()
+    async def process_response_metadata(self, grpc_call: Call):
+        metadata = await grpc_call.initial_metadata()
+        if "set-cookie" in metadata:
+            self._cookie = metadata["set-cookie"]
 
-        return cookie
-
-    async def _fetch_chain_cookie(self, metadata_query_provider: Callable):
-        metadata = await metadata_query_provider()
-        cookie_info = next((value for key, value in metadata if key == "set-cookie"), None)
-
-        if cookie_info is None:
-            raise RuntimeError(f"Error fetching chain cookie ({metadata})")
-
-        self._chain_cookie = cookie_info
-
-    async def _fetch_exchange_cookie(self, metadata_query_provider: Callable):
-        metadata = await metadata_query_provider()
-        cookie_info = next((value for key, value in metadata if key == "set-cookie"), None)
-
-        if cookie_info is None:
-            cookie_info = ""
-
-        self._exchange_cookie = cookie_info
-
-    def _check_chain_cookie_expiration(self):
-        if self._is_cookie_expired(cookie_data=self._chain_cookie):
-            self._chain_cookie = None
-
-    def _check_exchange_cookie_expiration(self):
-        if self._is_cookie_expired(cookie_data=self._exchange_cookie):
-            self._exchange_cookie = None
+    def _check_cookie_expiration(self):
+        if self._is_cookie_expired(cookie_data=self._cookie):
+            self._cookie = None
 
     def _is_cookie_expired(self, cookie_data: str) -> bool:
         # The cookies for these nodes do not expire
         return False
 
 
+class ExpiringCookieAssistant(CookieAssistant):
+    def __init__(self, expiration_time_keys_sequence: List[str], time_format: str):
+        self._cookie: Optional[str] = None
+        self._expiration_time_keys_sequence = expiration_time_keys_sequence
+        self._time_format = time_format
+
+    @classmethod
+    def for_kubernetes_public_server(cls):
+        return cls(
+            expiration_time_keys_sequence=["grpc-cookie", "expires"],
+            time_format="%a, %d-%b-%Y %H:%M:%S %Z",
+        )
+
+    def cookie(self) -> Optional[str]:
+        self._check_cookie_expiration()
+
+        return self._cookie
+
+    async def process_response_metadata(self, grpc_call: Call):
+        metadata = await grpc_call.initial_metadata()
+        if "set-cookie" in metadata:
+            self._cookie = metadata["set-cookie"]
+
+    def _check_cookie_expiration(self):
+        if self._is_cookie_expired():
+            self._cookie = None
+
+    def _is_cookie_expired(self) -> bool:
+        is_expired = False
+
+        if self._cookie is not None:
+            cookie = SimpleCookie()
+            cookie.load(self._cookie)
+            cookie_map = cookie
+
+            for key in self._expiration_time_keys_sequence[:-1]:
+                cookie_map = cookie.get(key, {})
+
+            expiration_data: Optional[str] = cookie_map.get(self._expiration_time_keys_sequence[-1], None)
+            if expiration_data is not None:
+                expiration_time = datetime.datetime.strptime(expiration_data, self._time_format)
+                is_expired = datetime.datetime.utcnow() >= expiration_time
+
+        return is_expired
+
+
 class DisabledCookieAssistant(CookieAssistant):
-    async def chain_cookie(self, metadata_query_provider: Callable) -> str:
-        pass
-
-    async def exchange_cookie(self, metadata_query_provider: Callable) -> str:
-        pass
-
-    async def chain_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
+    def cookie(self) -> Optional[str]:
         return None
 
-    async def exchange_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
-        return None
+    async def process_response_metadata(self, grpc_call: Call):
+        pass
 
 
 class Network:
@@ -180,7 +112,9 @@ class Network:
         chain_id: str,
         fee_denom: str,
         env: str,
-        cookie_assistant: CookieAssistant,
+        chain_cookie_assistant: CookieAssistant,
+        exchange_cookie_assistant: CookieAssistant,
+        explorer_cookie_assistant: CookieAssistant,
         use_secure_connection: bool = False,
     ):
         self.lcd_endpoint = lcd_endpoint
@@ -192,7 +126,9 @@ class Network:
         self.chain_id = chain_id
         self.fee_denom = fee_denom
         self.env = env
-        self.cookie_assistant = cookie_assistant
+        self.chain_cookie_assistant = chain_cookie_assistant
+        self.exchange_cookie_assistant = exchange_cookie_assistant
+        self.explorer_cookie_assistant = explorer_cookie_assistant
         self.use_secure_connection = use_secure_connection
 
     @classmethod
@@ -207,7 +143,9 @@ class Network:
             chain_id="injective-777",
             fee_denom="inj",
             env="devnet",
-            cookie_assistant=DisabledCookieAssistant(),
+            chain_cookie_assistant=DisabledCookieAssistant(),
+            exchange_cookie_assistant=DisabledCookieAssistant(),
+            explorer_cookie_assistant=DisabledCookieAssistant(),
         )
 
     @classmethod
@@ -226,7 +164,9 @@ class Network:
             grpc_exchange_endpoint = "testnet.sentry.exchange.grpc.injective.network:443"
             grpc_explorer_endpoint = "testnet.sentry.explorer.grpc.injective.network:443"
             chain_stream_endpoint = "testnet.sentry.chain.stream.injective.network:443"
-            cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+            chain_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+            exchange_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+            explorer_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
             use_secure_connection = True
         else:
             lcd_endpoint = "https://testnet.lcd.injective.network:443"
@@ -235,7 +175,9 @@ class Network:
             grpc_exchange_endpoint = "testnet.exchange.grpc.injective.network:443"
             grpc_explorer_endpoint = "testnet.explorer.grpc.injective.network:443"
             chain_stream_endpoint = "testnet.chain.stream.injective.network:443"
-            cookie_assistant = DisabledCookieAssistant()
+            chain_cookie_assistant = DisabledCookieAssistant()
+            exchange_cookie_assistant = DisabledCookieAssistant()
+            explorer_cookie_assistant = DisabledCookieAssistant()
             use_secure_connection = True
 
         return cls(
@@ -248,7 +190,9 @@ class Network:
             chain_id="injective-888",
             fee_denom="inj",
             env="testnet",
-            cookie_assistant=cookie_assistant,
+            chain_cookie_assistant=chain_cookie_assistant,
+            exchange_cookie_assistant=exchange_cookie_assistant,
+            explorer_cookie_assistant=explorer_cookie_assistant,
             use_secure_connection=use_secure_connection,
         )
 
@@ -266,7 +210,9 @@ class Network:
         grpc_exchange_endpoint = "sentry.exchange.grpc.injective.network:443"
         grpc_explorer_endpoint = "sentry.explorer.grpc.injective.network:443"
         chain_stream_endpoint = "sentry.chain.stream.injective.network:443"
-        cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+        chain_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+        exchange_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
+        explorer_cookie_assistant = BareMetalLoadBalancedCookieAssistant()
         use_secure_connection = True
 
         return cls(
@@ -279,7 +225,9 @@ class Network:
             chain_id="injective-1",
             fee_denom="inj",
             env="mainnet",
-            cookie_assistant=cookie_assistant,
+            chain_cookie_assistant=chain_cookie_assistant,
+            exchange_cookie_assistant=exchange_cookie_assistant,
+            explorer_cookie_assistant=explorer_cookie_assistant,
             use_secure_connection=use_secure_connection,
         )
 
@@ -295,7 +243,9 @@ class Network:
             chain_id="injective-1",
             fee_denom="inj",
             env="local",
-            cookie_assistant=DisabledCookieAssistant(),
+            chain_cookie_assistant=DisabledCookieAssistant(),
+            exchange_cookie_assistant=DisabledCookieAssistant(),
+            explorer_cookie_assistant=DisabledCookieAssistant(),
             use_secure_connection=False,
         )
 
@@ -310,10 +260,14 @@ class Network:
         chain_stream_endpoint,
         chain_id,
         env,
-        cookie_assistant: Optional[CookieAssistant] = None,
+        chain_cookie_assistant: Optional[CookieAssistant] = None,
+        exchange_cookie_assistant: Optional[CookieAssistant] = None,
+        explorer_cookie_assistant: Optional[CookieAssistant] = None,
         use_secure_connection: bool = False,
     ):
-        assistant = cookie_assistant or DisabledCookieAssistant()
+        chain_assistant = chain_cookie_assistant or DisabledCookieAssistant()
+        exchange_assistant = exchange_cookie_assistant or DisabledCookieAssistant()
+        explorer_assistant = explorer_cookie_assistant or DisabledCookieAssistant()
         return cls(
             lcd_endpoint=lcd_endpoint,
             tm_websocket_endpoint=tm_websocket_endpoint,
@@ -324,15 +278,11 @@ class Network:
             chain_id=chain_id,
             fee_denom="inj",
             env=env,
-            cookie_assistant=assistant,
+            chain_cookie_assistant=chain_assistant,
+            exchange_cookie_assistant=exchange_assistant,
+            explorer_cookie_assistant=explorer_assistant,
             use_secure_connection=use_secure_connection,
         )
 
     def string(self):
         return self.env
-
-    async def chain_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
-        return await self.cookie_assistant.chain_metadata(metadata_query_provider=metadata_query_provider)
-
-    async def exchange_metadata(self, metadata_query_provider: Callable) -> Tuple[Tuple[str, str]]:
-        return await self.cookie_assistant.exchange_metadata(metadata_query_provider=metadata_query_provider)

--- a/pyinjective/core/tx/grpc/tendermint_grpc_api.py
+++ b/pyinjective/core/tx/grpc/tendermint_grpc_api.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Optional
 from grpc.aio import Channel
 
 from pyinjective.client.model.pagination import PaginationOption
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.base.tendermint.v1beta1 import (
     query_pb2 as tendermint_query,
     query_pb2_grpc as tendermint_query_grpc,
@@ -11,9 +12,9 @@ from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class TendermintGrpcApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = tendermint_query_grpc.ServiceStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def fetch_node_info(self) -> Dict[str, Any]:
         request = tendermint_query.GetNodeInfoRequest()

--- a/pyinjective/core/tx/grpc/tx_grpc_api.py
+++ b/pyinjective/core/tx/grpc/tx_grpc_api.py
@@ -2,14 +2,15 @@ from typing import Any, Callable, Dict
 
 from grpc.aio import Channel
 
+from pyinjective.core.network import CookieAssistant
 from pyinjective.proto.cosmos.tx.v1beta1 import service_pb2 as tx_service, service_pb2_grpc as tx_service_grpc
 from pyinjective.utils.grpc_api_request_assistant import GrpcApiRequestAssistant
 
 
 class TxGrpcApi:
-    def __init__(self, channel: Channel, metadata_provider: Callable):
+    def __init__(self, channel: Channel, cookie_assistant: CookieAssistant):
         self._stub = tx_service_grpc.ServiceStub(channel)
-        self._assistant = GrpcApiRequestAssistant(metadata_provider=metadata_provider)
+        self._assistant = GrpcApiRequestAssistant(cookie_assistant=cookie_assistant)
 
     async def simulate(self, tx_bytes: bytes) -> Dict[str, Any]:
         request = tx_service.SimulateRequest(tx_bytes=tx_bytes)

--- a/pyinjective/utils/grpc_api_stream_assistant.py
+++ b/pyinjective/utils/grpc_api_stream_assistant.py
@@ -4,11 +4,13 @@ from typing import Callable, Optional
 from google.protobuf import json_format
 from grpc import RpcError
 
+from pyinjective.core.network import CookieAssistant
+
 
 class GrpcApiStreamAssistant:
-    def __init__(self, metadata_provider: Callable):
+    def __init__(self, cookie_assistant: CookieAssistant):
         super().__init__()
-        self._metadata_provider = metadata_provider
+        self._cookie_assistant = cookie_assistant
 
     async def listen_stream(
         self,
@@ -18,7 +20,7 @@ class GrpcApiStreamAssistant:
         on_end_callback: Optional[Callable] = None,
         on_status_callback: Optional[Callable] = None,
     ):
-        metadata = await self._metadata_provider()
+        metadata = self._cookie_assistant.metadata()
         stream = call(request, metadata=metadata)
 
         try:

--- a/tests/client/chain/grpc/test_chain_grpc_auth_api.py
+++ b/tests/client/chain/grpc/test_chain_grpc_auth_api.py
@@ -6,7 +6,7 @@ from google.protobuf import any_pb2
 
 from pyinjective.client.chain.grpc.chain_grpc_auth_api import ChainGrpcAuthApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.cosmos.auth.v1beta1 import auth_pb2 as auth_pb, query_pb2 as auth_query_pb
 from pyinjective.proto.cosmos.base.query.v1beta1 import pagination_pb2 as pagination_pb
 from pyinjective.proto.injective.crypto.v1beta1.ethsecp256k1 import keys_pb2 as keys_pb
@@ -34,11 +34,7 @@ class TestChainGrpcAuthApi:
         )
         auth_servicer.auth_params.append(auth_query_pb.QueryParamsResponse(params=params))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcAuthApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = auth_servicer
+        api = self._api_instance(servicer=auth_servicer)
 
         module_params = await api.fetch_module_params()
         expected_params = {
@@ -78,11 +74,7 @@ class TestChainGrpcAuthApi:
         any_account.Pack(account, type_url_prefix="")
         auth_servicer.account_responses.append(auth_query_pb.QueryAccountResponse(account=any_account))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcAuthApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = auth_servicer
+        api = self._api_instance(servicer=auth_servicer)
 
         response_account = await api.fetch_account(address="inj1knhahceyp57j5x7xh69p7utegnnnfgxavmahjr")
         expected_account = {
@@ -138,11 +130,7 @@ class TestChainGrpcAuthApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcAuthApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = auth_servicer
+        api = self._api_instance(servicer=auth_servicer)
 
         pagination_option = PaginationOption(
             key="011ab4075a94245dff7338e3042db5b7cc3f42e1",
@@ -170,5 +158,12 @@ class TestChainGrpcAuthApi:
         assert result_pagination.next_key == base64.b64decode(response_pagination["nextKey"])
         assert result_pagination.total == int(response_pagination["total"])
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = ChainGrpcAuthApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/chain/grpc/test_chain_grpc_bank_api.py
+++ b/tests/client/chain/grpc/test_chain_grpc_bank_api.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinjective.client.chain.grpc.chain_grpc_bank_api import ChainGrpcBankApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.cosmos.bank.v1beta1 import bank_pb2 as bank_pb, query_pb2 as bank_query_pb
 from pyinjective.proto.cosmos.base.query.v1beta1 import pagination_pb2 as pagination_pb
 from pyinjective.proto.cosmos.base.v1beta1 import coin_pb2 as coin_pb
@@ -26,11 +26,7 @@ class TestChainGrpcBankApi:
         params = bank_pb.Params(default_send_enabled=True)
         bank_servicer.bank_params.append(bank_query_pb.QueryParamsResponse(params=params))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         module_params = await api.fetch_module_params()
         expected_params = {
@@ -50,11 +46,7 @@ class TestChainGrpcBankApi:
         balance = coin_pb.Coin(denom="inj", amount="988987297011197594664")
         bank_servicer.balance_responses.append(bank_query_pb.QueryBalanceResponse(balance=balance))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         bank_balance = await api.fetch_balance(
             account_address="inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r", denom="inj"
@@ -71,11 +63,7 @@ class TestChainGrpcBankApi:
         balance = coin_pb.Coin(denom="inj", amount="988987297011197594664")
         bank_servicer.balance_responses.append(bank_query_pb.QueryBalanceResponse(balance=balance))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         bank_balance = await api.fetch_balance(
             account_address="inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r", denom="inj"
@@ -105,11 +93,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         bank_balances = await api.fetch_balances(
             account_address="inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r",
@@ -137,11 +121,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         balances = await api.fetch_spendable_balances(
             account_address="inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r",
@@ -168,11 +148,7 @@ class TestChainGrpcBankApi:
             bank_query_pb.QuerySpendableBalanceByDenomResponse(balance=first_balance)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         balances = await api.fetch_spendable_balances_by_denom(
             account_address="inj1cml96vmptgw99syqrrz8az79xer2pcgp0a885r",
@@ -210,11 +186,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         total_supply = await api.fetch_total_supply()
         next_key = "factory/inj1vkrp72xd67plcggcfjtjelqa4t5a093xljf2vj/inj1spw6nd0pj3kd3fgjljhuqpc8tv72a9v89myuja"
@@ -243,11 +215,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         total_supply = await api.fetch_supply_of(denom=first_supply.denom)
         expected_supply = {"amount": {"denom": first_supply.denom, "amount": first_supply.amount}}
@@ -284,11 +252,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         denom_metadata = await api.fetch_denom_metadata(denom=metadata.base)
 
@@ -347,11 +311,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         denoms_metadata = await api.fetch_denoms_metadata(
             pagination=PaginationOption(
@@ -405,11 +365,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         denoms_metadata = await api.fetch_denom_owners(
             denom=balance.denom,
@@ -460,11 +416,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcBankApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = bank_servicer
+        api = self._api_instance(servicer=bank_servicer)
 
         denoms_metadata = await api.fetch_send_enabled(
             denoms=[send_enabled.denom],
@@ -489,5 +441,12 @@ class TestChainGrpcBankApi:
 
         assert expected_denoms_metadata == denoms_metadata
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = ChainGrpcBankApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/chain/grpc/test_chain_grpc_exchange_api.py
+++ b/tests/client/chain/grpc/test_chain_grpc_exchange_api.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinjective.client.chain.grpc.chain_grpc_exchange_api import ChainGrpcExchangeApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.cosmos.base.v1beta1 import coin_pb2 as coin_pb
 from pyinjective.proto.injective.exchange.v1beta1 import (
     exchange_pb2 as exchange_pb,
@@ -59,11 +59,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.exchange_params.append(exchange_query_pb.QueryExchangeParamsResponse(params=params))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         module_params = await api.fetch_exchange_params()
         expected_params = {
@@ -123,11 +119,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountDepositsResponse(deposits={deposit_denom: deposit})
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         deposits = await api.fetch_subaccount_deposits(
             subaccount_id="0x5303d92e49a619bb29de8fb6f59c0e7589213cc8000000000000000000000001",
@@ -158,11 +150,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountDepositResponse(deposits=deposit)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         deposit_response = await api.fetch_subaccount_deposit(
             subaccount_id="0x5303d92e49a619bb29de8fb6f59c0e7589213cc8000000000000000000000001",
@@ -195,11 +183,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QueryExchangeBalancesResponse(balances=[balance])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         balances_response = await api.fetch_exchange_balances()
         expected_balances = {
@@ -236,11 +220,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         volume_response = await api.fetch_aggregate_volume(account="inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r")
         expected_volume = {
@@ -289,11 +269,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         volume_response = await api.fetch_aggregate_volumes(
             accounts=[account_volume.account],
@@ -342,11 +318,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         volume_response = await api.fetch_aggregate_market_volume(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
@@ -379,11 +351,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         volume_response = await api.fetch_aggregate_market_volumes(
             market_ids=[market_volume.market_id],
@@ -414,11 +382,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         denom_decimal = await api.fetch_denom_decimal(denom="inj")
         expected_decimal = {"decimal": str(decimal)}
@@ -440,11 +404,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         denom_decimals = await api.fetch_denom_decimals(denoms=[denom_decimal.denom])
         expected_decimals = {
@@ -481,11 +441,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         status_string = exchange_pb.MarketStatus.Name(market.status)
         markets = await api.fetch_spot_markets(
@@ -534,11 +490,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         response_market = await api.fetch_spot_market(
             market_id=market.market_id,
@@ -592,11 +544,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         status_string = exchange_pb.MarketStatus.Name(market.status)
         markets = await api.fetch_full_spot_markets(
@@ -662,11 +610,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         status_string = exchange_pb.MarketStatus.Name(market.status)
         market_response = await api.fetch_full_spot_market(
@@ -717,11 +661,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orderbook = await api.fetch_spot_orderbook(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -765,11 +705,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_trader_spot_orders(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -807,11 +743,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_account_address_spot_orders(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -849,11 +781,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_spot_orders_by_hashes(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -904,11 +832,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_subaccount_orders(
             subaccount_id="0x5303d92e49a619bb29de8fb6f59c0e7589213cc8000000000000000000000001",
@@ -957,11 +881,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_trader_spot_transient_orders(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -993,11 +913,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.spot_mid_price_and_tob_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         prices = await api.fetch_spot_mid_price_and_tob(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -1022,11 +938,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.derivative_mid_price_and_tob_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         prices = await api.fetch_derivative_mid_price_and_tob(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe",
@@ -1059,11 +971,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orderbook = await api.fetch_derivative_orderbook(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1106,11 +1014,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_trader_derivative_orders(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1150,11 +1054,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_account_address_derivative_orders(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1194,11 +1094,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_derivative_orders_by_hashes(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1239,11 +1135,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_trader_derivative_transient_orders(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1320,11 +1212,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         status_string = exchange_pb.MarketStatus.Name(market.status)
         markets = await api.fetch_derivative_markets(
@@ -1434,11 +1322,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         status_string = exchange_pb.MarketStatus.Name(market.status)
         market_response = await api.fetch_derivative_market(
@@ -1500,11 +1384,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.derivative_market_address_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         address = await api.fetch_derivative_market_address(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -1524,11 +1404,7 @@ class TestChainGrpcBankApi:
         response = exchange_query_pb.QuerySubaccountTradeNonceResponse(nonce=1234567879)
         exchange_servicer.subaccount_trade_nonce_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         nonce = await api.fetch_subaccount_trade_nonce(
             subaccount_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20000000000000000000000000",
@@ -1560,11 +1436,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QueryPositionsResponse(state=[derivative_position])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         positions = await api.fetch_positions()
         expected_positions = {
@@ -1606,11 +1478,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountPositionsResponse(state=[derivative_position])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         positions = await api.fetch_subaccount_positions(subaccount_id=derivative_position.subaccount_id)
         expected_positions = {
@@ -1649,11 +1517,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountPositionInMarketResponse(state=position)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         position_response = await api.fetch_subaccount_position_in_market(
             subaccount_id=subaccount_id,
@@ -1689,11 +1553,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountEffectivePositionInMarketResponse(state=effective_position)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         position_response = await api.fetch_subaccount_effective_position_in_market(
             subaccount_id=subaccount_id,
@@ -1726,11 +1586,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QueryPerpetualMarketInfoResponse(info=perpetual_market_info)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         market_info = await api.fetch_perpetual_market_info(market_id=perpetual_market_info.market_id)
         expected_market_info = {
@@ -1761,11 +1617,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QueryExpiryFuturesMarketInfoResponse(info=expiry_futures_market_info)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         market_info = await api.fetch_expiry_futures_market_info(market_id=expiry_futures_market_info.market_id)
         expected_market_info = {
@@ -1794,11 +1646,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QueryPerpetualMarketFundingResponse(state=perpetual_market_funding)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         funding = await api.fetch_perpetual_market_funding(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
@@ -1835,11 +1683,7 @@ class TestChainGrpcBankApi:
             exchange_query_pb.QuerySubaccountOrderMetadataResponse(metadata=[subaccount_order_metadata])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         metadata_response = await api.fetch_subaccount_order_metadata(
             subaccount_id="0x5303d92e49a619bb29de8fb6f59c0e7589213cc8000000000000000000000001"
@@ -1872,11 +1716,7 @@ class TestChainGrpcBankApi:
         response = exchange_query_pb.QueryTradeRewardPointsResponse(account_trade_reward_points=[points])
         exchange_servicer.trade_reward_points_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         trade_reward_points = await api.fetch_trade_reward_points(
             accounts=["inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r"],
@@ -1895,11 +1735,7 @@ class TestChainGrpcBankApi:
         response = exchange_query_pb.QueryTradeRewardPointsResponse(account_trade_reward_points=[points])
         exchange_servicer.pending_trade_reward_points_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         trade_reward_points = await api.fetch_pending_trade_reward_points(
             accounts=["inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r"],
@@ -1961,11 +1797,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.trade_reward_campaign_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         trade_reward_campaign = await api.fetch_trade_reward_campaign()
         expected_campaign = {
@@ -2044,11 +1876,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.fee_discount_account_info_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         fee_discount = await api.fetch_fee_discount_account_info(account="inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r")
         expected_fee_discount = {
@@ -2091,11 +1919,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         schedule = await api.fetch_fee_discount_schedule()
         expected_schedule = {
@@ -2137,11 +1961,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         mismatches = await api.fetch_balance_mismatches(dust_factor=20)
         expected_mismatches = {
@@ -2178,11 +1998,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         balance = await api.fetch_balance_with_balance_holds()
         expected_balance = {
@@ -2214,11 +2030,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         statistics = await api.fetch_fee_discount_tier_statistics()
         expected_statistics = {
@@ -2249,11 +2061,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.mito_vault_infos_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         mito_vaults = await api.fetch_mito_vault_infos()
         expected_mito_vaults = {
@@ -2277,11 +2085,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         market_id_response = await api.fetch_market_id_from_vault(
             vault_address="inj1zlh5sqevkfphtwnu9cul8p89vseme2eqt0snn9"
@@ -2312,11 +2116,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         records = await api.fetch_historical_trade_records(market_id=trade_record.market_id)
         expected_records = {
@@ -2346,11 +2146,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.is_opted_out_of_rewards_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         is_opted_out = await api.fetch_is_opted_out_of_rewards(account="inj1zlh5sqevkfphtwnu9cul8p89vseme2eqt0snn9")
         expected_is_opted_out = {
@@ -2369,11 +2165,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.opted_out_of_rewards_accounts_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         opted_out = await api.fetch_opted_out_of_rewards_accounts()
         expected_opted_out = {
@@ -2408,11 +2200,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.market_volatility_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         volatility = await api.fetch_market_volatility(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -2474,11 +2262,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.binary_options_markets_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         markets = await api.fetch_binary_options_markets(status="Active")
         expected_markets = {
@@ -2524,11 +2308,7 @@ class TestChainGrpcBankApi:
         response = exchange_query_pb.QueryTraderDerivativeConditionalOrdersResponse(orders=[order])
         exchange_servicer.trader_derivative_conditional_orders_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         orders = await api.fetch_trader_derivative_conditional_orders(
             subaccount_id="0x5303d92e49a619bb29de8fb6f59c0e7589213cc8000000000000000000000001",
@@ -2560,11 +2340,7 @@ class TestChainGrpcBankApi:
         )
         exchange_servicer.market_atomic_execution_fee_multiplier_responses.append(response)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcExchangeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = exchange_servicer
+        api = self._api_instance(servicer=exchange_servicer)
 
         multiplier = await api.fetch_market_atomic_execution_fee_multiplier(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6",
@@ -2575,5 +2351,12 @@ class TestChainGrpcBankApi:
 
         assert multiplier == expected_multiplier
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = ChainGrpcExchangeApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/chain/grpc/test_chain_grpc_token_factory_api.py
+++ b/tests/client/chain/grpc/test_chain_grpc_token_factory_api.py
@@ -2,7 +2,7 @@ import grpc
 import pytest
 
 from pyinjective.client.chain.grpc.chain_grpc_token_factory_api import ChainGrpcTokenFactoryApi
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.cosmos.base.v1beta1 import coin_pb2 as coin_pb
 from pyinjective.proto.injective.tokenfactory.v1beta1 import (
     authorityMetadata_pb2 as token_factory_authority_metadata_pb,
@@ -30,11 +30,7 @@ class TestChainGrpcTokenFactoryApi:
         )
         token_factory_query_servicer.params_responses.append(token_factory_query_pb.QueryParamsResponse(params=params))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcTokenFactoryApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._query_stub = token_factory_query_servicer
+        api = self._api_instance(servicer=token_factory_query_servicer)
 
         module_params = await api.fetch_module_params()
         expected_params = {
@@ -61,11 +57,7 @@ class TestChainGrpcTokenFactoryApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcTokenFactoryApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._query_stub = token_factory_query_servicer
+        api = self._api_instance(servicer=token_factory_query_servicer)
 
         metadata = await api.fetch_denom_authority_metadata(
             creator=authority_metadata.admin,
@@ -89,11 +81,7 @@ class TestChainGrpcTokenFactoryApi:
             token_factory_query_pb.QueryDenomsFromCreatorResponse(denoms=[denom])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcTokenFactoryApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._query_stub = token_factory_query_servicer
+        api = self._api_instance(servicer=token_factory_query_servicer)
 
         denoms = await api.fetch_denoms_from_creator(creator="inj1ady3s7whq30l4fx8sj3x6muv5mx4dfdlcpv8n7")
         expected_denoms = {"denoms": [denom]}
@@ -126,11 +114,7 @@ class TestChainGrpcTokenFactoryApi:
             token_factory_query_pb.QueryModuleStateResponse(state=state)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcTokenFactoryApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._query_stub = token_factory_query_servicer
+        api = self._api_instance(servicer=token_factory_query_servicer)
 
         state = await api.fetch_tokenfactory_module_state()
         expected_state = {
@@ -155,5 +139,12 @@ class TestChainGrpcTokenFactoryApi:
 
         assert state == expected_state
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = ChainGrpcTokenFactoryApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._query_stub = servicer
+
+        return api

--- a/tests/client/chain/grpc/test_chain_grpc_wasm_api.py
+++ b/tests/client/chain/grpc/test_chain_grpc_wasm_api.py
@@ -6,7 +6,7 @@ import pytest
 
 from pyinjective.client.chain.grpc.chain_grpc_wasm_api import ChainGrpcWasmApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.cosmos.base.query.v1beta1 import pagination_pb2 as pagination_pb
 from pyinjective.proto.cosmwasm.wasm.v1 import query_pb2 as wasm_query_pb, types_pb2 as wasm_types_pb
 from tests.client.chain.grpc.configurable_wasm_query_servicer import ConfigurableWasmQueryServicer
@@ -33,11 +33,7 @@ class TestChainGrpcBankApi:
         )
         wasm_servicer.params_responses.append(wasm_query_pb.QueryParamsResponse(params=params))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         module_params = await api.fetch_module_params()
         expected_params = {
@@ -77,11 +73,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_contract_info(address=address)
         expected_contract_info = {
@@ -130,11 +122,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_contract_history(
             address="inj18pp4vjwucpgg4nw3rr4wh4zyjg9ct5t8v9wqgj",
@@ -183,11 +171,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_contracts_by_code(
             code_id=3770,
@@ -231,11 +215,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_all_contracts_state(
             address="inj1z4l7jc8dj3y9484aqcrmf6y8mcctvkmm9zkf7n",
@@ -266,11 +246,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_raw_contract_state(
             address="inj1z4l7jc8dj3y9484aqcrmf6y8mcctvkmm9zkf7n",
@@ -294,11 +270,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_smart_contract_state(
             address="inj1z4l7jc8dj3y9484aqcrmf6y8mcctvkmm9zkf7n",
@@ -333,11 +305,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         info = await api.fetch_code(code_id=code_info_response.code_id)
         expected_contract_info = {
@@ -384,11 +352,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         codes = await api.fetch_codes(
             pagination=PaginationOption(
@@ -436,11 +400,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         codes = await api.fetch_pinned_codes(
             pagination=PaginationOption(
@@ -478,11 +438,7 @@ class TestChainGrpcBankApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
-
-        api = ChainGrpcWasmApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = wasm_servicer
+        api = self._api_instance(servicer=wasm_servicer)
 
         codes = await api.fetch_contracts_by_creator(
             creator_address="inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku",
@@ -501,5 +457,12 @@ class TestChainGrpcBankApi:
 
         assert codes == expected_codes
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = ChainGrpcWasmApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/grpc/test_indexer_grpc_account_api.py
+++ b/tests/client/indexer/grpc/test_indexer_grpc_account_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc.indexer_grpc_account_api import IndexerGrpcAccountApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_accounts_rpc_pb2 as exchange_accounts_pb
 from tests.client.indexer.configurable_account_query_servicer import ConfigurableAccountQueryServicer
 
@@ -34,11 +34,7 @@ class TestIndexerGrpcAccountApi:
         )
         account_servicer.portfolio_responses.append(exchange_accounts_pb.PortfolioResponse(portfolio=portfolio))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         account_address = "inj14au322k9munkmx5wrchz9q30juf5wjgz2cfqku"
         result_portfolio = await api.fetch_portfolio(account_address=account_address)
@@ -84,11 +80,7 @@ class TestIndexerGrpcAccountApi:
             exchange_accounts_pb.OrderStatesResponse(spot_order_states=[order_state])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_order_states = await api.fetch_order_states(spot_order_hashes=[order_state.order_hash])
         expected_order_states = {
@@ -124,11 +116,7 @@ class TestIndexerGrpcAccountApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_subaccounts_list = await api.fetch_subaccounts_list(address="testAddress")
         expected_subaccounts_list = {
@@ -156,11 +144,7 @@ class TestIndexerGrpcAccountApi:
             exchange_accounts_pb.SubaccountBalancesListResponse(balances=[balance])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_subaccount_balances_list = await api.fetch_subaccount_balances_list(
             subaccount_id=balance.subaccount_id, denoms=[balance.denom]
@@ -200,11 +184,7 @@ class TestIndexerGrpcAccountApi:
             exchange_accounts_pb.SubaccountBalanceEndpointResponse(balance=balance)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_subaccount_balance = await api.fetch_subaccount_balance(
             subaccount_id=balance.subaccount_id,
@@ -249,11 +229,7 @@ class TestIndexerGrpcAccountApi:
             exchange_accounts_pb.SubaccountHistoryResponse(transfers=[transfer], paging=paging)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_subaccount_history = await api.fetch_subaccount_history(
             subaccount_id=transfer.dst_subaccount_id,
@@ -297,11 +273,7 @@ class TestIndexerGrpcAccountApi:
             exchange_accounts_pb.SubaccountOrderSummaryResponse(spot_orders_total=0, derivative_orders_total=20)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_subaccount_order_summary = await api.fetch_subaccount_order_summary(
             subaccount_id="0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000",
@@ -330,11 +302,7 @@ class TestIndexerGrpcAccountApi:
 
         account_servicer.rewards_responses.append(exchange_accounts_pb.RewardsResponse(rewards=[reward]))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_rewards = await api.fetch_rewards(account_address=reward.account_address, epoch=1)
         expected_rewards = {
@@ -372,11 +340,7 @@ class TestIndexerGrpcAccountApi:
 
         account_servicer.rewards_responses.append(exchange_accounts_pb.RewardsResponse(rewards=[reward]))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAccountApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = account_servicer
+        api = self._api_instance(servicer=account_servicer)
 
         result_rewards = await api.fetch_rewards(account_address=reward.account_address, epoch=1)
         expected_rewards = {
@@ -396,5 +360,12 @@ class TestIndexerGrpcAccountApi:
 
         assert result_rewards == expected_rewards
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcAccountApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/grpc/test_indexer_grpc_derivative_api.py
+++ b/tests/client/indexer/grpc/test_indexer_grpc_derivative_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc.indexer_grpc_derivative_api import IndexerGrpcDerivativeApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_derivative_exchange_rpc_pb2 as exchange_derivative_pb
 from tests.client.indexer.configurable_derivative_query_servicer import ConfigurableDerivativeQueryServicer
 
@@ -67,11 +67,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_markets = await api.fetch_markets(
             market_statuses=[market.market_status],
@@ -174,11 +170,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_market = await api.fetch_market(market_id=market.market_id)
         expected_market = {
@@ -263,11 +255,7 @@ class TestIndexerGrpcDerivativeApi:
             exchange_derivative_pb.BinaryOptionsMarketsResponse(markets=[market], paging=paging)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_markets = await api.fetch_binary_options_markets(
             market_status=market.market_status,
@@ -355,11 +343,7 @@ class TestIndexerGrpcDerivativeApi:
             exchange_derivative_pb.BinaryOptionsMarketResponse(market=market)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_markets = await api.fetch_binary_options_market(market_id=market.market_id)
         expected_markets = {
@@ -422,11 +406,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orderbook = await api.fetch_orderbook_v2(
             market_id="0x17ef48032cb24375ba7c2e39f384e56433bcab20cbee9a7357e4cba2eb00abe6"
@@ -488,11 +468,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orderbook = await api.fetch_orderbooks_v2(market_ids=[single_orderbook.market_id])
         expected_orderbook = {
@@ -563,11 +539,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_orders(
             market_ids=[order.market_id],
@@ -654,11 +626,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_positions(
             market_ids=[position.market_id],
@@ -729,11 +697,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_positions_v2(
             market_ids=[position.market_id],
@@ -798,11 +762,7 @@ class TestIndexerGrpcDerivativeApi:
             exchange_derivative_pb.LiquidablePositionsResponse(positions=[position])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_liquidable_positions(
             market_id=position.market_id,
@@ -854,11 +814,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_funding_payments(
             market_ids=[payment.market_id],
@@ -910,11 +866,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_funding_rates(
             market_id=funding_rate.market_id,
@@ -981,11 +933,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_trades = await api.fetch_trades(
             market_ids=[trade.market_id],
@@ -1077,11 +1025,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_subaccount_orders_list(
             subaccount_id=order.subaccount_id,
@@ -1163,11 +1107,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_trades = await api.fetch_subaccount_trades_list(
             subaccount_id=trade.subaccount_id,
@@ -1245,11 +1185,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_orders = await api.fetch_orders_history(
             subaccount_id=order.subaccount_id,
@@ -1344,11 +1280,7 @@ class TestIndexerGrpcDerivativeApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         result_trades = await api.fetch_trades_v2(
             market_ids=[trade.market_id],
@@ -1400,5 +1332,12 @@ class TestIndexerGrpcDerivativeApi:
 
         assert result_trades == expected_trades
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcDerivativeApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/grpc/test_indexer_grpc_explorer_api.py
+++ b/tests/client/indexer/grpc/test_indexer_grpc_explorer_api.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc.indexer_grpc_explorer_api import IndexerGrpcExplorerApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_explorer_rpc_pb2 as exchange_explorer_pb
 from tests.client.indexer.configurable_explorer_query_servicer import ConfigurableExplorerQueryServicer
 
@@ -90,11 +90,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_txs = await api.fetch_account_txs(
             address="inj1phd706jqzd9wznkk5hgsfkrc8jqxv0kmlj0kex",
@@ -245,11 +241,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_contract_txs = await api.fetch_contract_txs(
             address="inj1phd706jqzd9wznkk5hgsfkrc8jqxv0kmlj0kex",
@@ -345,11 +337,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_blocks = await api.fetch_blocks(
             before=221419,
@@ -418,11 +406,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_block = await api.fetch_block(block_id=str(block_info.height))
         expected_block = {
@@ -496,11 +480,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_validators = await api.fetch_validators()
         expected_validators = {
@@ -581,11 +561,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_validator = await api.fetch_validator(address=validator.operator_address)
         expected_validator = {
@@ -645,11 +621,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_validator = await api.fetch_validator_uptime(address="injvaloper156t3yxd4udv0h9gwagfcmwnmm3quy0nph7tyh5")
         expected_validator = {
@@ -716,11 +688,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_txs = await api.fetch_txs(
             before=221439,
@@ -837,11 +805,7 @@ class TestIndexerGrpcExplorerApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_tx = await api.fetch_tx_by_tx_hash(tx_hash=tx_data.hash)
         expected_tx = {
@@ -921,11 +885,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetPeggyDepositTxsResponse(field=[tx_data])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_tx = await api.fetch_peggy_deposit_txs(
             sender=tx_data.sender,
@@ -985,11 +945,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetPeggyWithdrawalTxsResponse(field=[tx_data])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_tx = await api.fetch_peggy_withdrawal_txs(
             sender=tx_data.sender,
@@ -1056,11 +1012,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetIBCTransferTxsResponse(field=[tx_data])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_tx = await api.fetch_ibc_transfer_txs(
             sender=tx_data.sender,
@@ -1135,11 +1087,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetWasmCodesResponse(paging=paging, data=[wasm_code])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_codes = await api.fetch_wasm_codes(
             from_number=1,
@@ -1214,11 +1162,7 @@ class TestIndexerGrpcExplorerApi:
 
         explorer_servicer.wasm_code_by_id_responses.append(wasm_code)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_code = await api.fetch_wasm_code_by_id(code_id=wasm_code.code_id)
         expected_wasm_code = {
@@ -1285,11 +1229,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetWasmContractsResponse(paging=paging, data=[wasm_contract])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_contracts = await api.fetch_wasm_contracts(
             code_id=wasm_contract.code_id,
@@ -1368,11 +1308,7 @@ class TestIndexerGrpcExplorerApi:
 
         explorer_servicer.wasm_contract_by_address_responses.append(wasm_contract)
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_contract = await api.fetch_wasm_contract_by_address(address=wasm_contract.address)
         expected_wasm_contract = {
@@ -1429,11 +1365,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetCw20BalanceResponse(field=[wasm_balance])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_contract = await api.fetch_cw20_balance(
             address=wasm_balance.account,
@@ -1483,11 +1415,7 @@ class TestIndexerGrpcExplorerApi:
 
         explorer_servicer.relayers_responses.append(exchange_explorer_pb.RelayersResponse(field=[relayers]))
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_wasm_contract = await api.fetch_relayers(
             market_ids=[relayers.market_id],
@@ -1532,11 +1460,7 @@ class TestIndexerGrpcExplorerApi:
             exchange_explorer_pb.GetBankTransfersResponse(paging=paging, data=[bank_transfer])
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcExplorerApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = explorer_servicer
+        api = self._api_instance(servicer=explorer_servicer)
 
         result_transfers = await api.fetch_bank_transfers(
             senders=[bank_transfer.sender],
@@ -1578,5 +1502,12 @@ class TestIndexerGrpcExplorerApi:
 
         assert result_transfers == expected_transfers
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcExplorerApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/grpc/test_indexer_grpc_oracle_api.py
+++ b/tests/client/indexer/grpc/test_indexer_grpc_oracle_api.py
@@ -2,7 +2,7 @@ import grpc
 import pytest
 
 from pyinjective.client.indexer.grpc.indexer_grpc_oracle_api import IndexerGrpcOracleApi
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_oracle_rpc_pb2 as exchange_oracle_pb
 from tests.client.indexer.configurable_oracle_query_servicer import ConfigurableOracleQueryServicer
 
@@ -32,11 +32,7 @@ class TestIndexerGrpcOracleApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcOracleApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = oracle_servicer
+        api = self._api_instance(servicer=oracle_servicer)
 
         result_oracle_list = await api.fetch_oracle_list()
         expected_oracle_list = {
@@ -66,11 +62,7 @@ class TestIndexerGrpcOracleApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcOracleApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = oracle_servicer
+        api = self._api_instance(servicer=oracle_servicer)
 
         result_oracle_list = await api.fetch_oracle_price(
             base_symbol="Gold",
@@ -82,5 +74,12 @@ class TestIndexerGrpcOracleApi:
 
         assert result_oracle_list == expected_oracle_list
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcOracleApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/grpc/test_indexer_grpc_spot_api.py
+++ b/tests/client/indexer/grpc/test_indexer_grpc_spot_api.py
@@ -3,7 +3,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc.indexer_grpc_spot_api import IndexerGrpcSpotApi
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_spot_exchange_rpc_pb2 as exchange_spot_pb
 from tests.client.indexer.configurable_spot_query_servicer import ConfigurableSpotQueryServicer
 
@@ -57,11 +57,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_markets = await api.fetch_markets(
             market_statuses=[market.market_status],
@@ -146,11 +142,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_market = await api.fetch_market(market_id=market.market_id)
         expected_market = {
@@ -215,11 +207,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_orderbook = await api.fetch_orderbook_v2(
             market_id="0x0611780ba69656949525013d947713300f56c37b6175e02f26bffa495c3208fe"
@@ -281,11 +269,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_orderbook = await api.fetch_orderbooks_v2(market_ids=[single_orderbook.market_id])
         expected_orderbook = {
@@ -348,11 +332,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_orders = await api.fetch_orders(
             market_ids=[order.market_id],
@@ -435,11 +415,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_trades = await api.fetch_trades(
             market_ids=[trade.market_id],
@@ -521,11 +497,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_orders = await api.fetch_subaccount_orders_list(
             subaccount_id=order.subaccount_id,
@@ -597,11 +569,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_trades = await api.fetch_subaccount_trades_list(
             subaccount_id=trade.subaccount_id,
@@ -672,11 +640,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_orders = await api.fetch_orders_history(
             subaccount_id=order.subaccount_id,
@@ -759,11 +723,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_history = await api.fetch_atomic_swap_history(
             address=atomic_swap.sender,
@@ -838,11 +798,7 @@ class TestIndexerGrpcSpotApi:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotApi(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         result_trades = await api.fetch_trades_v2(
             market_ids=[trade.market_id],
@@ -892,5 +848,12 @@ class TestIndexerGrpcSpotApi:
 
         assert result_trades == expected_trades
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcSpotApi(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/stream_grpc/test_indexer_grpc_auction_stream.py
+++ b/tests/client/indexer/stream_grpc/test_indexer_grpc_auction_stream.py
@@ -4,7 +4,7 @@ import grpc
 import pytest
 
 from pyinjective.client.indexer.grpc_stream.indexer_grpc_auction_stream import IndexerGrpcAuctionStream
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_auction_rpc_pb2 as exchange_auction_pb
 from tests.client.indexer.configurable_auction_query_servicer import ConfigurableAuctionQueryServicer
 
@@ -29,11 +29,7 @@ class TestIndexerGrpcAuctionStream:
             exchange_auction_pb.StreamBidsResponse(bidder=bidder, bid_amount=amount, round=round, timestamp=timestamp)
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcAuctionStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = auction_servicer
+        api = self._api_instance(servicer=auction_servicer)
 
         bid_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -61,5 +57,12 @@ class TestIndexerGrpcAuctionStream:
         assert first_update == expected_update
         assert end_event.is_set()
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcAuctionStream(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/stream_grpc/test_indexer_grpc_derivative_stream.py
+++ b/tests/client/indexer/stream_grpc/test_indexer_grpc_derivative_stream.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc_stream.indexer_grpc_derivative_stream import IndexerGrpcDerivativeStream
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_derivative_exchange_rpc_pb2 as exchange_derivative_pb
 from tests.client.indexer.configurable_derivative_query_servicer import ConfigurableDerivativeQueryServicer
 
@@ -74,11 +74,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         market_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -178,11 +174,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         orderbook_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -266,11 +258,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         orderbook_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -348,11 +336,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         positions = asyncio.Queue()
         end_event = asyncio.Event()
@@ -434,11 +418,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         orders_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -542,11 +522,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         trade_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -646,11 +622,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         orders_history_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -744,11 +716,7 @@ class TestIndexerGrpcDerivativeStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcDerivativeStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = derivative_servicer
+        api = self._api_instance(servicer=derivative_servicer)
 
         trade_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -808,5 +776,12 @@ class TestIndexerGrpcDerivativeStream:
         assert first_update == expected_update
         assert end_event.is_set()
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcDerivativeStream(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/client/indexer/stream_grpc/test_indexer_grpc_spot_stream.py
+++ b/tests/client/indexer/stream_grpc/test_indexer_grpc_spot_stream.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyinjective.client.indexer.grpc_stream.indexer_grpc_spot_stream import IndexerGrpcSpotStream
 from pyinjective.client.model.pagination import PaginationOption
-from pyinjective.core.network import Network
+from pyinjective.core.network import DisabledCookieAssistant, Network
 from pyinjective.proto.exchange import injective_spot_exchange_rpc_pb2 as exchange_spot_pb
 from tests.client.indexer.configurable_spot_query_servicer import ConfigurableSpotQueryServicer
 
@@ -64,11 +64,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         market_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -159,11 +155,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         orderbook_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -247,11 +239,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         orderbook_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -333,11 +321,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         orders_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -429,11 +413,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         trade_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -526,11 +506,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         orders_history_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -617,11 +593,7 @@ class TestIndexerGrpcSpotStream:
             )
         )
 
-        network = Network.devnet()
-        channel = grpc.aio.insecure_channel(network.grpc_exchange_endpoint)
-
-        api = IndexerGrpcSpotStream(channel=channel, metadata_provider=lambda: self._dummy_metadata_provider())
-        api._stub = spot_servicer
+        api = self._api_instance(servicer=spot_servicer)
 
         trade_updates = asyncio.Queue()
         end_event = asyncio.Event()
@@ -679,5 +651,12 @@ class TestIndexerGrpcSpotStream:
         assert first_update == expected_update
         assert end_event.is_set()
 
-    async def _dummy_metadata_provider(self):
-        return None
+    def _api_instance(self, servicer):
+        network = Network.devnet()
+        channel = grpc.aio.insecure_channel(network.grpc_endpoint)
+        cookie_assistant = DisabledCookieAssistant()
+
+        api = IndexerGrpcSpotStream(channel=channel, cookie_assistant=cookie_assistant)
+        api._stub = servicer
+
+        return api

--- a/tests/core/test_network.py
+++ b/tests/core/test_network.py
@@ -51,7 +51,7 @@ class TestExpiringCookieAssistant:
             time_format=time_format,
         )
 
-        future_time = datetime.datetime.now(tz=ZoneInfo("Etc/GMT")) + datetime.timedelta(hours=1)
+        future_time = datetime.datetime.now(tz=ZoneInfo("Europe/London")) + datetime.timedelta(hours=1)
         formatted_time = future_time.strftime(time_format)
         cookie_value = (
             f"grpc-cookie=bb3a543cef4d9182587375c26556c15f; Expires={formatted_time};"

--- a/tests/core/test_network.py
+++ b/tests/core/test_network.py
@@ -51,7 +51,7 @@ class TestExpiringCookieAssistant:
             time_format=time_format,
         )
 
-        future_time = datetime.datetime.now(tz=ZoneInfo("GMT")) + datetime.timedelta(hours=1)
+        future_time = datetime.datetime.now(tz=ZoneInfo("Etc/GMT")) + datetime.timedelta(hours=1)
         formatted_time = future_time.strftime(time_format)
         cookie_value = (
             f"grpc-cookie=bb3a543cef4d9182587375c26556c15f; Expires={formatted_time};"

--- a/tests/core/test_network.py
+++ b/tests/core/test_network.py
@@ -1,5 +1,4 @@
 import datetime
-from zoneinfo import ZoneInfo
 
 import pytest
 from grpc.aio import Metadata
@@ -45,13 +44,14 @@ class TestExpiringCookieAssistant:
     @pytest.mark.asyncio
     async def test_cookie_expiration(self):
         time_format = "%a, %d-%b-%Y %H:%M:%S %Z"
+        gmt_timezone = datetime.timezone(offset=datetime.timedelta(seconds=0), name="GMT")
 
         assistant = ExpiringCookieAssistant(
             expiration_time_keys_sequence=["grpc-cookie", "expires"],
             time_format=time_format,
         )
 
-        future_time = datetime.datetime.now(tz=ZoneInfo("Europe/London")) + datetime.timedelta(hours=1)
+        future_time = datetime.datetime.now(tz=gmt_timezone) + datetime.timedelta(hours=1)
         formatted_time = future_time.strftime(time_format)
         cookie_value = (
             f"grpc-cookie=bb3a543cef4d9182587375c26556c15f; Expires={formatted_time};"
@@ -65,7 +65,7 @@ class TestExpiringCookieAssistant:
 
         assert assistant.cookie() == cookie_value
 
-        past_time = datetime.datetime.now(tz=ZoneInfo("GMT")) + datetime.timedelta(hours=-1)
+        past_time = datetime.datetime.now(tz=gmt_timezone) + datetime.timedelta(hours=-1)
         formatted_time = past_time.strftime(time_format)
         cookie_value = (
             f"grpc-cookie=bb3a543cef4d9182587375c26556c15f; Expires={formatted_time};"


### PR DESCRIPTION
- Changed the logic that processes cookies, to try and get the new cookie from any gRPC call response.
- Removed the extra initial request to get the cookie
- Removed the Kubernetes specific cookie assistant, and created a generic expiring cookie assistant.

https://injective-labs.atlassian.net/browse/CHAIN-20?atlOrigin=eyJpIjoiZDFlNmFlOWJjNjdkNGI3NjgwN2QwOTcyZDI3MDA2NzUiLCJwIjoiaiJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Simplified cookies management logic for better user experience.
    - Enhanced code readability by centralizing metadata retrieval logic.
    - Improved handling of cookies and metadata for structured management.
- **Tests**
    - Streamlined test setup for various APIs, improving code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->