### PR TITLE
Feat/add order data creation without order mask

### DIFF
--- a/pyinjective/composer.py
+++ b/pyinjective/composer.py
@@ -211,6 +211,21 @@ class Composer:
             cid=cid,
         )
 
+    def order_data_without_mask(
+        self,
+        market_id: str,
+        subaccount_id: str,
+        order_hash: Optional[str] = None,
+        cid: Optional[str] = None,
+    ) -> injective_exchange_tx_pb.OrderData:
+        return injective_exchange_tx_pb.OrderData(
+            market_id=market_id,
+            subaccount_id=subaccount_id,
+            order_hash=order_hash,
+            order_mask=1,
+            cid=cid,
+        )
+
     def SpotOrder(
         self,
         market_id: str,


### PR DESCRIPTION
- Added the  method in Composer, to allow order cancellation just using the order's identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to create order data without requiring a specific order mask, enhancing flexibility in order data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->