### PR TITLE
timeout height task should be canceled after deleting client

### DIFF
--- a/pyinjective/async_client.py
+++ b/pyinjective/async_client.py
@@ -3462,3 +3462,6 @@ class AsyncClient:
         if self._timeout_height_sync_task is not None:
             self._timeout_height_sync_task.cancel()
         self._timeout_height_sync_task = None
+
+    def __del__(self):
+        self._cancel_timeout_height_sync_task()


### PR DESCRIPTION
In case you should re initialize your injective async client multiple times, deleting the client won't stop sync timeout height task and it may increase the risk of memory leakage in the main program.

This two line makes sure when the client is no longer used, the timeout syncing will be stopped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management by ensuring asynchronous tasks are properly canceled when an `AsyncClient` instance is deleted, preventing potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->