### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,9 @@ Upgrade `pip` to the latest version, if you see these warnings:
   pip install injective-py
   ```
 
-3. Fetch latest denom config
-```
-poetry run python pyinjective/utils/fetch_metadata.py
-```
-
 Note that the [sync client](https://github.com/InjectiveLabs/sdk-python/blob/master/pyinjective/client.py) has been deprecated as of April 18, 2022. If you are using the sync client please make sure to transition to the [async client](https://github.com/InjectiveLabs/sdk-python/blob/master/pyinjective/async_client.py), for more information read [here](https://github.com/InjectiveLabs/sdk-python/issues/101)
 
-4. Run all unit tests in a development environment
+3. Run all unit tests in a development environment
 ```
 poetry run pytest -v
 ```


### PR DESCRIPTION
Removed `fetch_metadata.py` step since it's deprecated. Now markets & metadata are taken directly from the indexer endpoints and loaded in the SDK