### PR TITLE
[CP-508] add address creation from eth

### DIFF
--- a/pyinjective/wallet.py
+++ b/pyinjective/wallet.py
@@ -232,6 +232,13 @@ class Address:
         """Create an address instance from a bech32-encoded consensus address"""
         return cls._from_bech32(bech, BECH32_ADDR_CONS_PREFIX)
 
+    @classmethod
+    def from_eth_address(cls, eth_address: str) -> "Address":
+        """Create an address instance from a hex-encoded Ethereum address"""
+        eth_address_without_prefix = eth_address[2:] if eth_address.startswith("0x") else eth_address
+        bytes_representation = bytes.fromhex(eth_address_without_prefix)
+        return cls(bytes_representation)
+
     def _to_bech32(self, prefix: str) -> str:
         five_bit_r = convertbits(self.addr, 8, 5)
         assert five_bit_r is not None, "Unsuccessful bech32.convertbits call"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -28,3 +28,19 @@ class TestPublicKey:
         expected_address = Address(hashed_value[12:])
 
         assert expected_address == address
+
+
+class TestAddress:
+    def test_from_acc_bech32(self):
+        address = Address.from_acc_bech32("inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r")
+        assert address.to_acc_bech32() == "inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r"
+
+        eth_address = address.get_ethereum_address()
+        assert eth_address == "0xbdaedec95d563fb05240d6e01821008454c24c36"
+
+    def test_from_eth(self):
+        address = Address.from_eth_address("0xbdaedec95d563fb05240d6e01821008454c24c36")
+        assert address.to_acc_bech32() == "inj1hkhdaj2a2clmq5jq6mspsggqs32vynpk228q3r"
+
+        eth_address = address.get_ethereum_address()
+        assert eth_address == "0xbdaedec95d563fb05240d6e01821008454c24c36"


### PR DESCRIPTION
- Added a new class function in Address class to create instances from the Ethereum address

Solves [CP-508](https://injective-labs.atlassian.net/browse/CP-508)

[CP-508]: https://injective-labs.atlassian.net/browse/CP-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating an address from an Ethereum hex address string.
* **Tests**
  * Introduced tests to verify correct conversion between Bech32 and Ethereum address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->